### PR TITLE
add IEntityMap marker protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Also check out this blog post about [how DataScript fits into the current webdev
 
 ;; Implicit join, multi-valued attribute
 
-(let [schema {:aka {:cardinality :many}}
+(let [schema {:aka {:db/cardinality :db.cardinality/many}}
       conn   (d/create-conn schema)]
   (d/transact! conn [ { :db/id -1
                         :name  "Maksim"
@@ -99,7 +99,7 @@ The following features are supported:
 * Database as a value: each DB is an immutable value. New DBs are created on top of old ones, but old ones stay perfectly valid too
 * Triple store model
 * EA and AV indexes
-* Multi-valued attributes via `:cardinality :many`
+* Multi-valued attributes via `:db/cardinality :db.cardinality/many`
 * Database “mutations” via `transact!`
 * Callback-based analogue to txReportQueue via `listen!`
 
@@ -132,7 +132,7 @@ Expected soon:
 * DataScript is built totally from scratch and is not related by any means to the popular Clojure database Datomic
 * Runs in a browser
 * Simplified schema, not queryable
-* No need to declare attributes except for `:cardinality` `:many`
+* No need to declare attributes except for `:db/cardinality` `:db.cardinality/many`
 * Any value can be used as entity id, attribute or value. It’s better if they are immutable and fast to compare
 * No `db/ident` attributes, keywords are _literally_ attribute values, no integer id behind them
 * AV index for all datoms

--- a/src/datascript.cljs
+++ b/src/datascript.cljs
@@ -44,7 +44,10 @@
 (defrecord TxReport [db-before db-after tx-data])
 
 (defn multival? [db attr]
-  (= (get-in db [:schema attr :cardinality]) :many))
+  (= (get-in db [:schema attr :db/cardinality]) :db.cardinality/many))
+
+(defn ref? [db attr]
+  (= (get-in db [:schema attr :db/valueType]) :db.type/ref))
 
 (defn- match-tuple [tuple pattern]
   (every? true?
@@ -89,7 +92,7 @@
   (let [tx (inc (.-max-tx db))]
     (case op
       :db/add
-        (if (= :many (get-in db [:schema a :cardinality]))
+        (if (= :db.cardinality/many (get-in db [:schema a :db/cardinality]))
           (when (empty? (-search db [e a v]))
             [(->Datom e a v tx true)])
           (if-let [old-datom (first (-search db [e a]))]
@@ -347,14 +350,21 @@
       (not-empty (filter sequential? (:find query)))
         (aggregate query ins->sources))))
 
+(declare entity)
+
+(defn- follow-refs [db attr v]
+  (if (ref? db attr)
+    (entity db v)
+    v))
+
 (defn entity [db eid]
   (when-let [attrs (not-empty (get-in db [:ea eid]))]
     (specify!
       (merge {:db/id eid}
         (for [[attr datoms] attrs]
           (if (multival? db attr)
-            [attr (map :v datoms)]
-            [attr (.-v (first datoms))])))
+            [attr (map #(follow-refs db attr (:v %)) datoms)]
+            [attr (follow-refs db attr (.-v (first datoms)))])))
       IEntityMap)))
 
 (defn with [db entities]

--- a/test/test/datascript.cljs
+++ b/test/test/datascript.cljs
@@ -9,7 +9,7 @@
 
 
 (deftest test-with
-  (let [db  (-> (d/empty-db {:aka { :cardinality :many }})
+  (let [db  (-> (d/empty-db {:aka { :db/cardinality :db.cardinality/many }})
                 (d/with [[:db/add 1 :name "Ivan"]])
                 (d/with [[:db/add 1 :name "Petr"]])
                 (d/with [[:db/add 1 :aka  "Devil"]])
@@ -42,7 +42,7 @@
                #{["Petr"]}))))))
 
 (deftest test-retract-fns
-  (let [db (-> (d/empty-db {:aka { :cardinality :many }})
+  (let [db (-> (d/empty-db {:aka { :db/cardinality :db.cardinality/many }})
                (d/with [ { :db/id 1, :name  "Ivan", :age 15, :aka ["X" "Y" "Z"] }
                          { :db/id 2, :name  "Petr", :age 37 } ]))]
     (let [db (d/with db [ [:db.fn/retractEntity 1] ])]
@@ -71,7 +71,7 @@
 
 
 (deftest test-transact!
-  (let [conn (d/create-conn {:aka { :cardinality :many }})]
+  (let [conn (d/create-conn {:aka { :db/cardinality :db.cardinality/many }})]
     (d/transact! conn [[:db/add 1 :name "Ivan"]])
     (d/transact! conn [[:db/add 1 :name "Petr"]])
     (d/transact! conn [[:db/add 1 :aka  "Devil"]])
@@ -103,7 +103,7 @@
              [3 "Sergey" 30 (+ d/tx0 2)]}))))
 
 (deftest test-entity
-  (let [conn (d/create-conn {:aka {:cardinality :many}})
+  (let [conn (d/create-conn {:aka {:db/cardinality :db.cardinality/many}})
         p1   {:db/id 1, :name "Ivan", :age 19, :aka ["X" "Y"]}
         p2   {:db/id 2, :name "Ivan", :sex "male", :aka ["Z"]}
         t1   (d/transact! conn [p1 p2])]
@@ -136,8 +136,8 @@
 
 
 (deftest test-explode
-  (let [conn (d/create-conn { :aka { :cardinality :many }
-                              :also { :cardinality :many} })]
+  (let [conn (d/create-conn { :aka { :db/cardinality :db.cardinality/many }
+                              :also { :db/cardinality :db.cardinality/many} })]
     (d/transact! conn [{:db/id -1
                         :name  "Ivan"
                         :age   16
@@ -183,7 +183,7 @@
 
 
 (deftest test-q-many
-  (let [db (-> (d/empty-db {:aka {:cardinality :many}})
+  (let [db (-> (d/empty-db {:aka {:db/cardinality :db.cardinality/many}})
                (d/with [ [:db/add 1 :name "Ivan"]
                          [:db/add 1 :aka  "ivolga"]
                          [:db/add 1 :aka  "pi"]


### PR DESCRIPTION
It's useful to be able to differentiate entity maps from plain
maps. This patch uses `specify!` to mark the returned maps as entity
maps.
