### PR TITLE
Add transaction functions

### DIFF
--- a/src/datascript.cljs
+++ b/src/datascript.cljs
@@ -83,7 +83,7 @@
         [:db/add eid a v]))
     (if (= (first entity) :db.fn/call)
       (let [[_ f & args] entity]
-        (vec (apply f db args)))
+        (mapcat #(entity->ops db %) (apply f db args)))
       [entity])))
 
 (defn- op->tx-data [db [op e a v]]

--- a/test/test/datascript.cljs
+++ b/test/test/datascript.cljs
@@ -92,7 +92,7 @@
                                                    :where [[?e :name ?name]
                                                            [?e :age ?age]]}
                                                   db name))]
-                    [[:db/add eid :age (inc age)]]
+                    [{:db/id eid :age (inc age)} [:db/add eid :had-birthday true]]
                     (throw (js/Error. (str "No entity with name: " name)))
 ))]
     (d/transact! conn [{:db/id 1 :name "Ivan" :age 31}])
@@ -108,8 +108,10 @@
            #{["Devil"] ["Tupen"]}))
     (is (thrown-with-msg? js/Error #"No entity with name: Bob"
                           (d/transact! conn [[:db.fn/call inc-age "Bob"]])))
-    (let [{:keys [db-after]} (d/transact! conn [[:db.fn/call inc-age "Petr"]])]
-      (is (= (:age (d/entity db-after 1)) 32)))))
+    (let [{:keys [db-after]} (d/transact! conn [[:db.fn/call inc-age "Petr"]])
+          e (d/entity db-after 1)]
+      (is (= (:age e) 32))
+      (is (:had-birthday e)))))
 
 
 (deftest test-resolve-eid


### PR DESCRIPTION
Database functions/transaction functions.

No need to install functions in database of course. [:db.fn/call f args] will be called in the transaction with the current value of db as the first argument to f. Throwing an Error in f will abort the transaction. See test for an example.
