### PR TITLE
Keyword ident

### DIFF
--- a/src/datascript.cljs
+++ b/src/datascript.cljs
@@ -117,7 +117,9 @@
   (->
     (reduce transact-datom db tx-data)
     (update-in [:max-tx] inc)
-    (assoc      :max-eid (reduce max (.-max-eid db) (map :e tx-data)))))
+    (assoc      :max-eid (reduce max (.-max-eid db) (for [{e :e} tx-data
+                                                          :when (number? e)]
+                                                      e)))))
 
 
 ;; QUERIES

--- a/test/test/datascript.cljs
+++ b/test/test/datascript.cljs
@@ -139,6 +139,17 @@
     (is (= (d/entity @conn 1) p1))
     (is (= (d/entity @conn 2) p2))))
 
+(deftest test-keyword-ident
+  (let [conn (d/create-conn {})
+        p1   {:db/id :ivan, :name "Ivan", :age 19}
+        p2   {:db/id -1, :name "Bob", :sex "male"}
+        t1 (d/transact! conn [p1])
+        t2 (d/transact! conn [p2])]
+    (is (= (d/entity (:db-after t1) :ivan) p1))
+    (is (= (-> (d/entity (:db-after t2) (get-in t2 [:tempids -1]))
+               (dissoc :db/id))
+           (dissoc p2 :db/id)))))
+
 (deftest test-listen!
   (let [conn    (d/create-conn)
         reports (atom [])]


### PR DESCRIPTION
From the README:

> Differences with Datomic:
> - Any value can be used as entity id, attribute or value. It’s better if they are immutable and fast to compare

Using a non number as an entity id breaks using a tempid in a transaction after that. This should fix that.
