### PR TITLE
Unroll :db.cardinality/many assertions

### DIFF
--- a/src/datascript/core.cljs
+++ b/src/datascript/core.cljs
@@ -151,7 +151,7 @@
 (defn- explode [db entity]
   (let [eid (:db/id entity)]
     (for [[a vs] (dissoc entity :db/id)
-          v      (if (and (sequential? vs)
+          v      (if (and (coll? vs)
                           (multival? db a))
                    vs [vs])]
       [:db/add eid a v])))

--- a/test/test/datascript.cljs
+++ b/test/test/datascript.cljs
@@ -231,23 +231,27 @@
 
 
 (deftest test-explode
-  (let [conn (d/create-conn { :aka { :db/cardinality :db.cardinality/many }
-                              :also { :db/cardinality :db.cardinality/many} })]
-    (d/transact! conn [{:db/id -1
-                        :name  "Ivan"
-                        :age   16
-                        :aka   ["Devil" "Tupen"]
-                        :also  "ok"}])
-    (is (= (d/q '[:find  ?n ?a
-                  :where [1 :name ?n]
-                         [1 :age ?a]] @conn)
-           #{["Ivan" 16]}))
-    (is (= (d/q '[:find  ?v
-                  :where [1 :also ?v]] @conn)
-           #{["ok"]}))
-    (is (= (d/q '[:find  ?v
-                  :where [1 :aka ?v]] @conn)
-           #{["Devil"] ["Tupen"]}))))
+  ;;Test that explode works properly with vectors, sets, and lists.
+  (doseq [coll [["Devil" "Tupen"]
+                #{"Devil" "Tupen"}
+                '("Devil" "Tupen")]]
+    (let [conn (d/create-conn { :aka { :db/cardinality :db.cardinality/many }
+                               :also { :db/cardinality :db.cardinality/many} })]
+      (d/transact! conn [{:db/id -1
+                          :name  "Ivan"
+                          :age   16
+                          :aka   coll
+                          :also  "ok"}])
+      (is (= (d/q '[:find  ?n ?a
+                    :where [1 :name ?n]
+                    [1 :age ?a]] @conn)
+             #{["Ivan" 16]}))
+      (is (= (d/q '[:find  ?v
+                    :where [1 :also ?v]] @conn)
+             #{["ok"]}))
+      (is (= (d/q '[:find  ?v
+                    :where [1 :aka ?v]] @conn)
+             #{["Devil"] ["Tupen"]})))))
 
 
 (deftest test-joins


### PR DESCRIPTION
With the latest (0.3.0) DataScript, `:db.cardinality/many` attributes are returned differently than they are in Datomic.

In DataScript:

``` clojure
(let [schema {:children {:db/cardinality :db.cardinality/many}}
      conn   (d/create-conn schema)]

      (d/transact! conn [{:db/id -1 :children #{"A" "B"}}])

      (->> (d/q '[:find ?e :where [?e :children _]]
                @conn)
           ffirst
           (d/entity @conn)
           :children)) ;;=> #{#{"B" "A"}}
```

whereas in Datomic the same code returns `#{"B" "A"}`.
Changing the transaction data to:

``` clojure
(d/transact! conn [{:db/id -1 :children "A"}
                   {:db/id -1 :children "B"}])
```

returns `#{"A" "B"}`.

If this is the desired behavior, would you be open to a pull request that makes

``` clojure
(d/transact! conn [{:db/id -1 :children #{"A" "B"}}])
```

equivalent to

``` clojure
(d/transact! conn [{:db/id -1 :children "A"}
                   {:db/id -1 :children "B"}])
```
