### PR TITLE
Add failing test case around entity navigation after (touch)

### DIFF
--- a/test/test/datascript.cljs
+++ b/test/test/datascript.cljs
@@ -195,7 +195,16 @@
     (testing "nested navigation"
       (is (= (-> (e 1) :children first :children) #{(e 100) (e 101)}))
       (is (= (-> (e 10) :children first :father) (e 10)))
-      (is (= (-> (e 10) :father :children) #{(e 10)})))
+      (is (= (-> (e 10) :father :children) #{(e 10)}))
+
+      (testing "after touch"
+        (let [e1  (e 1)
+              e10 (e 10)]
+          (d/touch e1)
+          (d/touch e10)
+          (is (= (-> e1 :children first :children) #{(e 100) (e 101)}))
+          (is (= (-> e10 :children first :father) (e 10)))
+          (is (= (-> e10 :father :children) #{(e 10)})))))
     
     (testing "backward navigation"
       (is (= (:_children (e 1))  nil))


### PR DESCRIPTION
I've really enjoyed playing with datascript!  It's a very nice contribution to the ClojureScript toolchain.  Thanks for your work on this!

It looks like there is some state/cache inconsistency around (touch) for card/many reference attrs.  I've added a failing test case to demonstrate the issue.  The bottom line is:

``` clojure
;; Using data from test.datascript/test-entity-refs
(-> (e 1) :children first :children)
; => #{(e 100) (e 101)}
(-> (e 1) :children first touch :children)
; => #{100 101}
```

(touch) is only intended for inspecting an entity when working at the REPL.  It should not be called in application code, and certainly should not be relied upon in your protocol implementations (-seq, -count, etc.).  I believe that pulling touch (and touched) out of the low-level implementation and into a top-level convenience function will greatly simplify and make more consistent your implementation of Entity.
