### PR TITLE
adding support for get-else, get-some and missing? as built-in preds

### DIFF
--- a/src/datascript/query.cljs
+++ b/src/datascript/query.cljs
@@ -2,7 +2,8 @@
   (:require
     [clojure.set :as set]
     [clojure.walk :as walk]
-    [datascript.core :as dc]))
+    [datascript.core :as dc]
+    [datascript.impl.entity :as de]))
 
 
 ;; Records
@@ -98,7 +99,7 @@
 
 (defn- -missing?
   [db e a]
-  (empty? (dc/-search db [e a])))
+  (nil? (get (de/entity db e) a)))
 
 (def built-ins {
   '= =, '== ==, 'not= not=, '!= not=, '< <, '> >, '<= <=, '>= >=, '+ +, '- -,

--- a/test/test/datascript.cljs
+++ b/test/test/datascript.cljs
@@ -426,10 +426,10 @@
 
 
 (deftest test-user-funs
-  (let [db (-> (d/empty-db)
+  (let [db (-> (d/empty-db {:parent {:parent {:db/valueType :db.valueType/ref}}})
                (d/db-with [ { :db/id 1, :name  "Ivan",  :age   15 }
-                            { :db/id 2, :name  "Petr",  :age   22, :height 240}
-                            { :db/id 3, :name  "Slava", :age   37 }]))]
+                            { :db/id 2, :name  "Petr",  :age   22, :height 240 :parent 1}
+                            { :db/id 3, :name  "Slava", :age   37 :parent 2}]))]
     (testing "get-else"
       (is (= (d/q '[:find ?e ?age ?height
                     :in $
@@ -450,6 +450,13 @@
                     :where [?e :age ?age]
                            [(missing? $ ?e :height)]] db)
              #{[1 15] [3 37]})))
+
+    (testing "missing? back-ref"
+      (is (= (d/q '[:find ?e
+                    :in $
+                    :where [?e :age ?age]
+                    [(missing? $ ?e :_parent)]] db)
+             #{[3]})))
 
     (testing "Built-in predicate"
       (is (= (d/q '[:find  ?e1 ?e2


### PR DESCRIPTION
Not sure if this is the best approach as it required passing along `context` to `-call-fn` in both `filter-by-pred` and `bind-by-fn` to allow resolving `$` to a source. This will also be necessary for `get-some`, `missing?` and similar though so I am going to run with it for now. 
