### PR TITLE
start prefix-context in solve-rules with full context to allow resolutio...

### DIFF
--- a/src/datascript/query.cljs
+++ b/src/datascript/query.cljs
@@ -381,7 +381,7 @@
         empty-rels?     (fn [context]
                           (some #(empty? (:tuples %)) (:rels context)))]
     (loop [stack (list {:prefix-clauses []
-                        :prefix-context (assoc context :rels [])
+                        :prefix-context context
                         :clauses        [clause]
                         :used-args      {}
                         :pending-guards {}})


### PR DESCRIPTION
Relating to: https://github.com/tonsky/datascript/issues/28

I made this change and all tests passed - but I would like to understand why it was previously purposely removing the :rels from the context? 
