### PR TITLE
adding missing aggregate fns (avg, median, variance and stddev)

### DIFF
--- a/test/test/datascript.cljs
+++ b/test/test/datascript.cljs
@@ -36,7 +36,7 @@
                #{["Tupen"]}))
 
         (is (= (into {} (d/entity db 1)) { :aka #{"Tupen"} }))))
-
+q
     (testing "Cannot retract what's not there"
       (let [db  (-> db
                     (d/db-with [[:db/retract 1 :name "Ivan"]]))]
@@ -754,6 +754,30 @@
                        3))
              #{[:red  [3 4 5] [1 2 3]]
                [:blue [7 8]   [7 8]]})))
+
+    (testing "avg aggregate" 
+      (is (= (ffirst (d/q '[:find (avg ?x) 
+                            :in [?x ...]]
+                           [10 15 20 35 75]))
+             31)))
+
+    (testing "median aggregate"
+      (is (= (ffirst (d/q '[:find (median ?x)
+                            :in [?x ...]]
+                           [10 15 20 35 75]))
+             20)))
+    
+    (testing "variance aggregate"
+      (is (= (ffirst (d/q '[:find (variance ?x)
+                            :in [?x ...]]
+                           [10 15 20 35 75]))
+              554)))
+
+    (testing "stddev aggregate"
+      (is (= (ffirst (d/q '[:find (stddev ?x) 
+                            :in [?x ...]]
+                          [10 15 20 35 75]))
+              23.53720459187964)))
 
     (testing "Custom aggregates"
       (is (= (set (d/q '[ :find ?color (?agg ?x)


### PR DESCRIPTION
I would have done these each in their own commit but there was enough mutual dependance (thus the refactor to a letfn) that it seemed appropriate to do it in one commit.
