### PR TITLE
Support overriding default expansion of component entities

### DIFF
--- a/src/datascript/pull_api.cljs
+++ b/src/datascript/pull_api.cljs
@@ -100,12 +100,6 @@
             component? (and ref? (dc/component? db attr))
             datom-val  (if forward? #(.-v %) #(.-e %))]
         (cond
-          (and forward? component?)
-          (->> found
-               (mapv datom-val)
-               (expand-frame attr-key multi?)
-               (conj frames parent))
-
           (contains? opts :subpattern)
           (->> (subpattern-frame (:subpattern opts)
                                  (mapv datom-val found)
@@ -116,6 +110,12 @@
           (recurse-attr db attr-key multi?
                         (mapv datom-val found)
                         eid parent frames)
+
+          (and forward? component?)
+          (->> found
+               (mapv datom-val)
+               (expand-frame attr-key multi?)
+               (conj frames parent))
           
           :else 
           (let [as-value  (cond->> datom-val

--- a/test/datascript/test/pull_api.cljs
+++ b/test/datascript/test/pull_api.cljs
@@ -170,7 +170,15 @@
 
   (testing "Non matching results are removed from collections"
     (is (= {:name "Petr" :child []}
-           (d/pull test-db '[:name {:child [:foo]}] 1)))))
+           (d/pull test-db '[:name {:child [:foo]}] 1))))
+
+  (testing "Map specs can override component expansion"
+    (let [parts {:name "Part A" :part [{:name "Part A.A"} {:name "Part A.B"}]}]
+      (is (= parts
+             (d/pull test-db '[:name {:part [:name]}] 10)))
+
+      (is (= parts
+             (d/pull test-db '[:name {:part 1}] 10))))))
 
 (deftest test-pull-recursion
   (let [db      (-> test-db


### PR DESCRIPTION
This patch reorders the `cond` in `pull-attr-datoms` to allow map specs to override the default behaviour of recursively expanding component entities.