### PR TITLE
First pass at fix for #58

### DIFF
--- a/test/datascript/test/pull_api.cljs
+++ b/test/datascript/test/pull_api.cljs
@@ -17,7 +17,10 @@
 
    :part   { :db/valueType :db.type/ref
              :db/isComponent true
-             :db/cardinality :db.cardinality/many }})
+             :db/cardinality :db.cardinality/many }
+   :spec   { :db/valueType :db.type/ref
+             :db/isComponent true
+             :db/cardinality :db.cardinality/one }})
 
 (def test-datoms
   (->>
@@ -92,13 +95,40 @@
                    :name "Part A.B.A",
                    :part
                    [{:db/id 17 :name "Part A.B.A.A"}
-                    {:db/id 18 :name "Part A.B.A.B"}]}]}]}]
+                    {:db/id 18 :name "Part A.B.A.B"}]}]}]}
+        rpart (update-in parts [:part 0 :part 0 :part]
+                         (partial into [{:db/id 10}]))
+        recdb (d/init-db
+               (concat test-datoms [(d/datom 12 :part 10)])
+               test-schema)
+
+        mutdb (d/init-db
+               (concat test-datoms [(d/datom 12 :part 10)
+                                    (d/datom 12 :spec 10)
+                                    (d/datom 10 :spec 13)
+                                    (d/datom 13 :spec 12)])
+               test-schema)]
+    
     (testing "Component entities are expanded recursively"
       (is (= parts (d/pull test-db '[:name :part] 10))))
 
     (testing "Reverse component references yield a single result"
       (is (= {:name "Part A.A" :_part {:db/id 10}}
-             (d/pull test-db [:name :_part] 11))))))
+             (d/pull test-db [:name :_part] 11))))
+
+    (testing "Reverse component references yield a single result"
+      (is (= {:name "Part A.A" :_part {:db/id 10}}
+             (d/pull test-db [:name :_part] 11))))
+    
+    (testing "Like explicit recursion, expansion will not allow loops"
+      (is (= rpart (d/pull recdb '[:name :part] 10))))
+
+    (testing "We don't expect this to actually pass to be honest, since
+to be honest I'm really not sure what constitutes sensible behaviour in
+this situation - this test will at least print out the result we currently
+get."
+      ;;(is (= :??? (d/pull mutdb '[:name :part :spec] 10)))
+      )))
 
 (deftest test-pull-wildcard
   (is (= {:db/id 1 :name "Petr" :aka ["Devil" "Tupen"]

--- a/test/datascript/test/pull_api.cljs
+++ b/test/datascript/test/pull_api.cljs
@@ -115,20 +115,9 @@
     (testing "Reverse component references yield a single result"
       (is (= {:name "Part A.A" :_part {:db/id 10}}
              (d/pull test-db [:name :_part] 11))))
-
-    (testing "Reverse component references yield a single result"
-      (is (= {:name "Part A.A" :_part {:db/id 10}}
-             (d/pull test-db [:name :_part] 11))))
     
     (testing "Like explicit recursion, expansion will not allow loops"
-      (is (= rpart (d/pull recdb '[:name :part] 10))))
-
-    (testing "We don't expect this to actually pass to be honest, since
-to be honest I'm really not sure what constitutes sensible behaviour in
-this situation - this test will at least print out the result we currently
-get."
-      ;;(is (= :??? (d/pull mutdb '[:name :part :spec] 10)))
-      )))
+      (is (= rpart (d/pull recdb '[:name :part] 10))))))
 
 (deftest test-pull-wildcard
   (is (= {:db/id 1 :name "Petr" :aka ["Devil" "Tupen"]


### PR DESCRIPTION
This PR provides similar behaviour to recursion specs (i.e. only returns a map containing `:db/id` for entities which have already been seen along a given path). I have to be honest, though, and say that I'm not convinced allowing loops on component attributes is the right way to go; `:db/isComponent` currently allows one to explicitly constrain parts of the schema more strictly than just `:db/ref` - in the pull API this is used to, for example, make the assumption that navigating a _reverse_ component relationship will yield precisely 0 or 1 results depending on whether the attribute exists on the given entity.

It also seems to violate the principle of least surprise (although granted, the original issue that caused this was clearly surprising, but it was caused by a separate issue) - To my mind `:db/isComponent` conveys information on multiple levels:

* On a schema level it indicates an explicit choice of a "contains" relationship over the less constrained, plain `:db/rel`.
* `transact` etc. use it to supported nested maps in transaction data.
* `db/retractEntity` uses it to make deletion decisions that are different from those of plain `:db/rel` based upon this constraint.
*  `touch` / `pull` / `pull-many` etc. use it to make expansion decisions based upon the implied contains constraint that are different from those of plain `:db/rel` - the single parent requirement, for example.

The latter items all seem to build upon the constraint provided by the first item - it therefore seems dangerous to remove the constraint itself.

For example this PR exhibits some rather odd behaviour if you give it graphs with multiple component attributes containing mutual cycles - see the commented out [test](https://github.com/dthume/datascript/blob/pull-component-recursion/test/datascript/test/pull_api.cljs#L130

On the one hand, it appears to be "technically" correct from the point of view of not returning entities which have already been seen along a given path, but on the other it doesn't seem particularly easy to work with.

All that said, perhaps I'm just overthinking things; if you decide you'd like to proceed with the PR, by all means let me know if there's anything you'd like changed.