### PR TITLE
Allow js api to create conn from db

### DIFF
--- a/src/datascript/js.cljs
+++ b/src/datascript/js.cljs
@@ -94,6 +94,10 @@
 (defn ^:export create_conn [& [schema]]
   (d/create-conn (schema->clj schema)))
 
+(defn ^:export conn_from [db]
+  (atom db 
+        :meta { :listeners  (atom {}) }))
+
 (defn ^:export db [conn]
   @conn)
 


### PR DESCRIPTION
Maybe I am going about this the wrong way,
but I am trying to deserialize a datascript database
from localstorage (a la your example here: https://github.com/tonsky/datascript-todo/blob/gh-pages/src/datascript_todo.cljs)
but via the vanilla js api.

There seems to be an asymmetry in the js api,
in that you can dereference a database from a conn,
but you cannot easily create a conn from a database.

My pull request is kind of a dumb hack.
Maybe it would be better for the original create-conn
function to be a multimethod or something.