### PR TITLE
Return nil from entity when passed nil eid

### DIFF
--- a/src/datascript/impl/entity.cljc
+++ b/src/datascript/impl/entity.cljc
@@ -8,8 +8,9 @@
   {:pre [(satisfies? dc/IDB db)
          (satisfies? dc/ISearch db)
          (satisfies? dc/IIndexAccess db)]}
-  (when-let [e (dc/entid db eid)]
-    (Entity. db e false {})))
+  (when-not (nil? eid)
+    (when-let [e (dc/entid db eid)]
+      (Entity. db e false {}))))
 
 (defn- entity-attr [db a datoms]
   (if (dc/multival? db a)

--- a/test/datascript/test/entity.cljc
+++ b/test/datascript/test/entity.cljc
@@ -26,7 +26,8 @@
 
     (is (= (pr-str (d/entity db 1) "{:db/id 1}")))
     (is (= (pr-str (let [e (d/entity db 1)] (:name e) e)) "{:name \"Ivan\", :db/id 1}"))
-    (is (= (pr-str (let [e (d/entity db 1)] (:unknown e) e)) "{:db/id 1}"))))
+    (is (= (pr-str (let [e (d/entity db 1)] (:unknown e) e)) "{:db/id 1}"))
+    (is (nil? (d/entity db nil)))))
 
 (deftest test-entity-refs
   (let [db (-> (d/empty-db {:father   {:db/valueType   :db.type/ref}


### PR DESCRIPTION
Fixes a problem where calling (d/entity db nil) will throw an "Expected number or lookup ref for entity id" error.