### PR TITLE
cljc breakout of DB and FilteredDB structures

### DIFF
--- a/src/datascript.cljc
+++ b/src/datascript.cljc
@@ -19,6 +19,10 @@
 (def  pull-many dp/pull-many)
 (def  touch de/touch)
 
+(def  datom? dc/datom?)
+(def  db? dc/db?)
+(def  filtered-db? dc/filtered-db?)
+
 (def ^:const tx0 dc/tx0)
 
 (defn attr->properties [k v]
@@ -155,32 +159,11 @@
 (defn unlisten! [conn key]
   (swap! (:listeners (meta conn)) dissoc key))
 
-
-(defn pr-db [db w opts]
-  (-write w "#datascript/DB {")
-  (-write w ":schema ")
-  (pr-writer (dc/-schema db) w opts)
-  (-write w ", :datoms ")
-  (pr-sequential-writer w
-    (fn [d w opts]
-      (pr-sequential-writer w pr-writer "[" " " "]" opts [(.-e d) (.-a d) (.-v d) (.-tx d)]))
-    "[" " " "]" opts (dc/-datoms db :eavt []))
-  (-write w "}"))
-
-(extend-protocol IPrintWithWriter
-  dc/DB
-  (-pr-writer [db w opts]
-    (pr-db db w opts))
-
-  dc/FilteredDB
-  (-pr-writer [db w opts]
-    (pr-db db w opts)))
-
 (defn db-from-reader [{:keys [schema datoms]}]
   (init-db (map (fn [[e a v tx]] (dc/Datom. e a v tx true)) datoms) schema))
 
 (cljs.reader/register-tag-parser! "datascript/Datom" dc/datom-from-reader)
-(cljs.reader/register-tag-parser! "datascript/DB"         db-from-reader)
+(cljs.reader/register-tag-parser! "datascript/DB"    db-from-reader)
 
 ;; Datomic compatibility layer
 

--- a/src/datascript/core.cljc
+++ b/src/datascript/core.cljc
@@ -478,30 +478,33 @@
     :max-eid 0
     :max-tx  tx0
     :rschema (rschema schema)
-    :__hash  (atom nil)}))
+    #?@(:clj [:__hash (atom nil)])}))
 
 (defn init-db [datoms & [schema]]
-  (let [datoms  (into-array datoms)
-        len     (alength datoms)
-        max-eid (if (pos? len) (.-e (aget datoms (dec len))) 0) ; assign before mutable sorts below
-        #?@(:cljs
-            [eavt    (btset/-btset-from-sorted-arr (.sort datoms cmp-datoms-eavt-quick) cmp-datoms-eavt)
-             aevt    (btset/-btset-from-sorted-arr (.sort datoms cmp-datoms-aevt-quick) cmp-datoms-aevt)
-             avet    (btset/-btset-from-sorted-arr (.sort datoms cmp-datoms-avet-quick) cmp-datoms-avet)]
-            :clj
-            [eavt    (btset/btset-by datoms cmp-datoms-eavt)
-             aevt    (btset/btset-by datoms cmp-datoms-aevt)
-             avet    (btset/btset-by datoms cmp-datoms-avet)])
-        max-tx  (transduce (map #(.-tx %)) max tx0 datoms)]
-    (map->DB {
-      :schema  (validate-schema schema)
-      :eavt    eavt
-      :aevt    aevt
-      :avet    avet
-      :max-eid max-eid
-      :max-tx  max-tx
-      :rschema (rschema schema)
-      :__hash  (atom nil)})))
+  (if (empty? datoms)
+    (empty-db schema)
+    (let [_ (validate-schema schema)
+          #?@(:cljs
+              [ds-arr  (into-array datoms)
+               eavt    (btset/-btset-from-sorted-arr (.sort ds-arr cmp-datoms-eavt-quick) cmp-datoms-eavt)
+               aevt    (btset/-btset-from-sorted-arr (.sort ds-arr cmp-datoms-aevt-quick) cmp-datoms-aevt)
+               avet    (btset/-btset-from-sorted-arr (.sort ds-arr cmp-datoms-avet-quick) cmp-datoms-avet)
+               max-eid (.-e (first (-rseq eavt)))]
+              :clj
+              [eavt    (btset/btset-by datoms cmp-datoms-eavt)
+               aevt    (btset/btset-by datoms cmp-datoms-aevt)
+               avet    (btset/btset-by datoms cmp-datoms-avet)
+               max-eid (.-e (first (rseq eavt)))])
+          max-tx (transduce (map #(.-tx %)) max tx0 eavt)]
+      (map->DB {
+        :schema  schema
+        :eavt    eavt
+        :aevt    aevt
+        :avet    avet
+        :max-eid max-eid
+        :max-tx  max-tx
+        :rschema (rschema schema)
+        #?@(:clj [:__hash (atom nil)])}))))
 
 (defn- equiv-db-index [x y]
   (and (= (count x) (count y))

--- a/test/datascript/test/core.cljc
+++ b/test/datascript/test/core.cljc
@@ -3,7 +3,10 @@
     [cemerick.cljs.test :refer [deftest is are testing with-test-out]])
   (:require
     [cemerick.cljs.test :as t]
-    [datascript :as d]))
+    [datascript :as d]
+    [datascript.core
+     #?@(:cljs [:refer-macros [defrecord-extendable-cljs]]
+         :clj  [:refer [defrecord-extendable-clj]])]))
 
 (enable-console-print!)
 
@@ -52,3 +55,17 @@
             (d/datom 2 :age 37)
             (d/datom 2 :name "Petr")]))
     ))
+
+
+;;
+;; verify that defrecord-extendable works with compiler/core macro configuration
+;; define dummy class which redefines hash, could produce either
+;; compiler or runtime error
+;;
+(#?(:cljs defrecord-extendable-cljs :clj defrecord-extendable-clj)
+   HashBeef [x]
+  #?@(:cljs [IHash   (-hash  [hb] 0xBEEF)]
+      :clj  [IHashEq (hasheq [hb] 0xBEEF)]))
+
+(deftest test-defrecord-extendable
+  (is (= 0xBEEF (-> (map->HashBeef {:x :ignored}) hash))))

--- a/test/datascript/test/core.cljc
+++ b/test/datascript/test/core.cljc
@@ -4,7 +4,7 @@
   (:require
     [cemerick.cljs.test :as t]
     [datascript :as d]
-    [datascript.core
+    [datascript.core :as dc
      #?@(:cljs [:refer-macros [defrecord-updatable-cljs]]
          :clj  [:refer [defrecord-updatable-clj]])]))
 
@@ -69,3 +69,10 @@
 
 (deftest test-defrecord-extendable
   (is (= 0xBEEF (-> (map->HashBeef {:x :ignored}) hash))))
+
+;; whitebox
+(deftest test-db-hash-cache
+  (let [db (dc/empty-db)]
+    (is (= nil (-> (.-__hash db) #?(:clj (deref)))))
+    (let [h (hash db)]
+      (is (= h (-> (.-__hash db) #?(:clj (deref))))))))

--- a/test/datascript/test/core.cljc
+++ b/test/datascript/test/core.cljc
@@ -5,8 +5,8 @@
     [cemerick.cljs.test :as t]
     [datascript :as d]
     [datascript.core
-     #?@(:cljs [:refer-macros [defrecord-extendable-cljs]]
-         :clj  [:refer [defrecord-extendable-clj]])]))
+     #?@(:cljs [:refer-macros [defrecord-updatable-cljs]]
+         :clj  [:refer [defrecord-updatable-clj]])]))
 
 (enable-console-print!)
 
@@ -62,7 +62,7 @@
 ;; define dummy class which redefines hash, could produce either
 ;; compiler or runtime error
 ;;
-(#?(:cljs defrecord-extendable-cljs :clj defrecord-extendable-clj)
+(#?(:cljs defrecord-updatable-cljs :clj defrecord-updatable-clj)
    HashBeef [x]
   #?@(:cljs [IHash   (-hash  [hb] 0xBEEF)]
       :clj  [IHashEq (hasheq [hb] 0xBEEF)]))

--- a/test/datascript/test/pull_api.cljc
+++ b/test/datascript/test/pull_api.cljc
@@ -122,7 +122,10 @@
 (deftest test-pull-wildcard
   (is (= {:db/id 1 :name "Petr" :aka ["Devil" "Tupen"]
           :child [{:db/id 2} {:db/id 3}]}
-         (d/pull test-db '[*] 1))))
+         (d/pull test-db '[*] 1)))
+
+  (is (= {:db/id 2 :name "David" :_child [{:db/id 1}]}
+         (d/pull test-db '[* :_child] 2))))
 
 (deftest test-pull-limit
   (let [db (d/init-db


### PR DESCRIPTION
* couple small fixes to Datom
* uses new defrecord-extendable-* macros to leverage defrecord, but allow overriding builtins
* possible mechanism to combine macros could be copied from prismatic, not yet tried
* DB: previous (and current) versions have `(seq)` support which returns a sequence of the `datoms`, but assoc, etc., will manipulate the DB structure directly. is this what we want? I might suggest removing the specialized seq, count methods until moving completely to the possible sorted-datom-set vision as a whole.

I will make cleanups in this branch, and once you're down with all of them, merge them into move-to-cljc for a final (singular) clean merge.