### PR TITLE
Pull API map spec non-component reversed attributes should return collections

### DIFF
--- a/src/datascript/pull_api.cljc
+++ b/src/datascript/pull_api.cljc
@@ -113,9 +113,9 @@
                (cond->> datoms
                  limit (into [] (take limit))))]
     (if found
-      (let [multi?     (dc/multival? db attr)
-            ref?       (dc/ref? db attr)
+      (let [ref?       (dc/ref? db attr)
             component? (and ref? (dc/component? db attr))
+            multi?     (if forward? (dc/multival? db attr) (not component?))
             datom-val  (if forward? (fn [^Datom d] (.-v d)) (fn [^Datom d] (.-e d)))]
         (cond
           (contains? opts :subpattern)
@@ -138,7 +138,7 @@
           :else 
           (let [as-value  (cond->> datom-val
                             ref? (comp #(hash-map :db/id %)))
-                single?   (if forward? (not multi?) component?)]
+                single?   (not multi?)]
             (->> (cond-> (into [] (map as-value) found)
                    single? first)
                  (update parent :kvps assoc! attr-key)

--- a/test/datascript/test/pull_api.cljc
+++ b/test/datascript/test/pull_api.cljc
@@ -37,6 +37,8 @@
      [9 :name  "Rebecca"]
      [1 :child 2]
      [1 :child 3]
+     [2 :father 1]
+     [3 :father 1]
      [6 :father 3]
      [10 :name  "Part A"]
      [11 :name  "Part A.A"]
@@ -75,7 +77,20 @@
          (d/pull test-db '[:name :_child] 2)))
 
   (is (= {:name "David" :_child [{:name "Petr"}]}
-         (d/pull test-db '[:name {:_child [:name]}] 2))))
+         (d/pull test-db '[:name {:_child [:name]}] 2)))
+
+  (testing "Reverse non-component references yield collections"
+    (is (= {:name "Thomas" :_father [{:db/id 6}]}
+           (d/pull test-db '[:name :_father] 3)))
+
+    (is (= {:name "Petr" :_father [{:db/id 2} {:db/id 3}]}
+           (d/pull test-db '[:name :_father] 1)))
+
+    (is (= {:name "Thomas" :_father [{:name "Matthew"}]}
+           (d/pull test-db '[:name {:_father [:name]}] 3)))
+
+    (is (= {:name "Petr" :_father [{:name "David"} {:name "Thomas"}]}
+           (d/pull test-db '[:name {:_father [:name]}] 1)))))
 
 (deftest test-pull-component-attr
   (let [parts {:name "Part A",
@@ -114,8 +129,11 @@
 
     (testing "Reverse component references yield a single result"
       (is (= {:name "Part A.A" :_part {:db/id 10}}
-             (d/pull test-db [:name :_part] 11))))
-    
+             (d/pull test-db [:name :_part] 11)))
+
+      (is (= {:name "Part A.A" :_part {:name "Part A"}}
+             (d/pull test-db [:name {:_part [:name]}] 11))))
+
     (testing "Like explicit recursion, expansion will not allow loops"
       (is (= rpart (d/pull recdb '[:name :part] 10))))))
 
@@ -124,7 +142,7 @@
           :child [{:db/id 2} {:db/id 3}]}
          (d/pull test-db '[*] 1)))
 
-  (is (= {:db/id 2 :name "David" :_child [{:db/id 1}]}
+  (is (= {:db/id 2 :name "David" :_child [{:db/id 1}] :father {:db/id 1}}
          (d/pull test-db '[* :_child] 2))))
 
 (deftest test-pull-limit


### PR DESCRIPTION
Hello.

With the pull api, if you reverse lookup a cardinality-one, non-component attribute inside a map spec, it only yields a single result, but it should yield a collection instead.

Here’s a test snippet to try to clarify. On the current `master` the top two tests will pass, but the bottom two tests (with map specs) will fail.

```clojure
(def test-schema {:father { :db/valueType :db.type/ref }})

(def test-datoms
  (->>
    [[1 :name  "Petr"]
     [2 :name  "David"]
     [3 :name  "Thomas"]
     [6 :name  "Matthew"]
     [2 :father 1]
     [3 :father 1]
     [6 :father 3]]
   (map #(apply d/datom %))))

(def test-db (d/init-db test-datoms test-schema))

(deftest test-pull-reverse-attr-spec
  (testing "Reverse non-component references yield collections"

    ;; Currently these two will pass
    (is (= {:name "Thomas" :_father [{:db/id 6}]}
           (d/pull test-db '[:name :_father] 3)))

    (is (= {:name "Petr" :_father [{:db/id 2} {:db/id 3}]}
           (d/pull test-db '[:name :_father] 1)))

    ;; But these two will fail
    (is (= {:name "Thomas" :_father [{:name "Matthew"}]}
           (d/pull test-db '[:name {:_father [:name]}] 3)))

    (is (= {:name "Petr" :_father [{:name "David"} {:name "Thomas"}]}
           (d/pull test-db '[:name {:_father [:name]}] 1)))))
```

This PR passes the tests, and brings the behaviour in line with Datomic, e.g. in the standard Datomic `mbrainz-1968-1973` db, this will yield the country name and a collection of all artist names:

```clojure
(d/pull db '[:country/name {:artist/_country [:artist/name]}] :country/GB)
```

I’m new to DataScript so my fix might not be the right way to do this.

Cheers!