### PR TITLE
Add Node.js REPL.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -16,9 +16,11 @@
   
   :jvm-opts ["-Xmx2g" "-server"]
 
-  :aliases {"test-clj" ["run" "-m" "datascript.test/test-all"]}
-  
-  :cljsbuild { 
+  :aliases {
+    "test-clj" ["run" "-m" "datascript.test/test-all"]
+    "noderepl" ["run" "-m" "clojure.main" "repl.clj"]}
+
+  :cljsbuild {
     :builds [
       { :id "release"
         :source-paths ["src" "bench/src"]

--- a/repl.clj
+++ b/repl.clj
@@ -1,0 +1,13 @@
+(require 'cljs.repl)
+(require 'cljs.build.api)
+(require 'cljs.repl.node)
+
+(cljs.build.api/build "src"
+  {:main 'datascript
+   :output-to "target/datascript.js"
+   :output-dir "target"
+   :verbose true})
+
+(cljs.repl/repl (cljs.repl.node/repl-env)
+  :watch "src"
+  :output-dir "target")


### PR DESCRIPTION
Since the browser REPLs are a bit clunky (and unnecessary) and LightTable's development has slowed down, I thought adding a Node.js REPL would be nice. (At least until `lein-cljsbuild` adds it.)

`lein noderepl` should launch it, provided you have Node installed somewhere.