### PR TITLE
Enable JS lookup refs

### DIFF
--- a/src/datascript/js.cljs
+++ b/src/datascript/js.cljs
@@ -74,18 +74,22 @@
 
 (defn ^:export pull [db pattern eid]
   (let [pattern (cljs.reader/read-string pattern)
+        eid (js->clj eid)
         results (d/pull db pattern eid)]
     (pull-result->js results)))
 
 (defn ^:export pull_many [db pattern eids]
   (let [pattern (cljs.reader/read-string pattern)
+        eids (js->clj eids)
         results (d/pull-many db pattern eids)]
     (pull-result->js results)))
 
 (defn ^:export db_with [db entities]
   (d/db-with db (entities->clj entities)))
 
-(def ^:export entity      d/entity)
+(defn ^:export entity [db eid]
+  (d/entity db (js->clj eid)))
+
 (def ^:export touch       d/touch)
 (def ^:export entity_db   d/entity-db)
 (def ^:export filter      d/filter)

--- a/test/js/tests.html
+++ b/test/js/tests.html
@@ -293,7 +293,21 @@
                     "father": {"name": "Ivan", ":db/id": 1}};
         assert_eq(expected, actual);
       }
-      
+
+      function test_lookup_refs() {
+        var schema = {"name": {":db/unique": ":db.unique/identity"}};
+        var db = d.db_with(d.empty_db(schema),
+                           [{":db/id": 1, "name": "Ivan"},
+                            {":db/id": 2, "name": "Oleg"}]);
+
+        assert_eq("Ivan", d.entity(db, ["name", "Ivan"]).get("name"));
+        assert_eq({"name": "Ivan"}, d.pull(db, '["name"]', ["name", "Ivan"]));
+        assert_eq_set(
+          [{"name": "Ivan"}, {"name": "Oleg"}],
+          d.pull_many(db, '["name"]', [["name", "Ivan"], ["name", "Oleg"]])
+        );
+      }
+
       function test_resolve_current_tx() {
         var schema = {"created-at": {":db/valueType":   ":db.type/ref"}};
         var conn = d.create_conn(schema);
@@ -422,6 +436,7 @@
                           test_tx_report,
                           test_entity,
                           test_entity_refs,
+                          test_lookup_refs,
                           test_pull,
                           test_resolve_current_tx,
                           test_q_relation,


### PR DESCRIPTION
Hello. I noticed lookup refs in JS weren’t working for `pull`, `pull_many`, or `entity` - this PR just parses entity id input with `js->clj` first to allow lookup refs through. Cheers.