### PR TITLE
Fix sneaky parens caught by humane-test-output

### DIFF
--- a/test/datascript/test/entity.cljc
+++ b/test/datascript/test/entity.cljc
@@ -29,7 +29,7 @@
     (is (= (into {} (d/entity db 2))
            {:name "Ivan", :sex "male", :aka #{"Z"}}))
 
-    (is (= (pr-str (d/entity db 1) "{:db/id 1}")))
+    (is (= (pr-str (d/entity db 1)) "{:db/id 1}"))
     (is (= (pr-str (let [e (d/entity db 1)] (:unknown e) e)) "{:db/id 1}"))
     ;; read back in to account for unordered-ness
     (is (= (edn/read-string (pr-str (let [e (d/entity db 1)] (:name e) e)))


### PR DESCRIPTION
[humane-test-output](https://github.com/pjstadig/humane-test-output) plugin caught a common paren oversight when I tried to run the tests locally.