### PR TITLE
Bring explicitly supported value types in line with Datomic

### DIFF
--- a/src/datascript/core.cljc
+++ b/src/datascript/core.cljc
@@ -514,6 +514,11 @@
                      :key k
                      :value v}))))
 
+(def supported-value-types
+  #{:db.type/keyword :db.type/string :db.type/boolean :db.type/long
+    :db.type/bigint :db.type/float :db.type/double :db.type/bigdec :db.type/ref
+    :db.type/instant :db.type/uuid :db.type/uri :db.type/bytes})
+
 (defn- validate-schema [schema]
   (doseq [[a kv] schema]
     (let [comp? (:db/isComponent kv false)]
@@ -524,7 +529,7 @@
                          :attribute a
                          :key       :db/isComponent}))))
     (validate-schema-key a :db/unique (:db/unique kv) #{:db.unique/value :db.unique/identity})
-    (validate-schema-key a :db/valueType (:db/valueType kv) #{:db.type/ref})
+    (validate-schema-key a :db/valueType (:db/valueType kv) supported-value-types)
     (validate-schema-key a :db/cardinality (:db/cardinality kv) #{:db.cardinality/one :db.cardinality/many}))
   schema)
 


### PR DESCRIPTION
It's valuable to be able to dump (at least a larger subset) Datomic schema into DataScript automatically. This change adds support for more types. The only dubious one is :db.type/double since that can't round-trip.

I don't believe there should be any performance impact, and this is a very handy change to have.