### PR TITLE
Fix null pointer exception when `contains?` is called with an entity.

### DIFF
--- a/src/datascript/impl/entity.cljc
+++ b/src/datascript/impl/entity.cljc
@@ -125,7 +125,7 @@
 
        clojure.lang.Associative
        (equiv [e o]       (equiv-entity e o))
-       (containsKey [e k] (lookup-entity e k))
+       (containsKey [e k] (not= ::nf (lookup-entity e k ::nf)))
        (entryAt [e k]     (some->> (lookup-entity e k) (clojure.lang.MapEntry. k)))
 
        (empty [e]         (throw (UnsupportedOperationException.)))

--- a/test/datascript/test/entity.cljc
+++ b/test/datascript/test/entity.cljc
@@ -22,6 +22,8 @@
     (is (= (e :name) "Ivan")) ; IFn form
     (is (= (:age  e) 19))
     (is (= (:aka  e) #{"X" "Y"}))
+    (is (= true (contains? e :age)))
+    (is (= false (contains? e :not-found)))
     (is (= (into {} e)
            {:name "Ivan", :age 19, :aka #{"X" "Y"}}))
     (is (= (into {} (d/entity db 1))


### PR DESCRIPTION
Using `contains?` on an entity on the JVM caused a null pointer exception because `contains?` expects the `containsKey` method to return a boolean.
I've updated the implementation of Entity to do the right thing on the JVM just like what's done on the cljs implementation (using the not-found arity of key lookup).