### PR TITLE
Let old-value for db.fn/cas be nil

### DIFF
--- a/src/datascript/db.cljc
+++ b/src/datascript/db.cljc
@@ -976,7 +976,6 @@
                     _ (validate-attr a entity)
                     ov (if (ref? db a) (entid-strict db ov) ov)
                     nv (if (ref? db a) (entid-strict db nv) nv)
-                    _ (validate-val ov entity)
                     _ (validate-val nv entity)
                     datoms (-search db [e a])]
                 (if (multival? db a)

--- a/test/datascript/test/transact.cljc
+++ b/test/datascript/test/transact.cljc
@@ -109,7 +109,14 @@
     (d/transact! conn [[:db.fn/cas 1 :label :y :z]])
     (is (= (:label (d/entity @conn 1)) #{:x :y :z}))
     (is (thrown-with-msg? Throwable #":db.fn/cas failed on datom \[1 :label \(:x :y :z\)\], expected :s"
-                          (d/transact! conn [[:db.fn/cas 1 :label :s :t]])))))
+                          (d/transact! conn [[:db.fn/cas 1 :label :s :t]]))))
+
+  (let [conn (d/create-conn)]
+    (d/transact! conn [[:db/add 1 :name "Ivan"]])
+    (d/transact! conn [[:db.fn/cas 1 :age nil 42]])
+    (is (= (:age (d/entity @conn 1)) 42))
+    (is (thrown-with-msg? Throwable #":db.fn/cas failed on datom \[1 :age 42\], expected nil"
+                          (d/transact! conn [[:db.fn/cas 1 :age nil 4711]])))))
 
 (deftest test-db-fn
   (let [conn (d/create-conn {:aka { :db/cardinality :db.cardinality/many }})


### PR DESCRIPTION
Fixes #126 by not validating old-value (letting it be nil).