### PR TITLE
Query function bindings fail to handle colliding bindings

### DIFF
--- a/src/datascript/query.cljc
+++ b/src/datascript/query.cljc
@@ -439,7 +439,7 @@
                            (reduce sum-rel))
                       (prod-rel production (empty-rel binding))))
                   (prod-rel (assoc production [:tuples] []) (empty-rel binding)))]
-    (update-in context [:rels] conj new-rel)))
+    (update-in context [:rels] collapse-rels new-rel)))
 
 ;;; RULES
 


### PR DESCRIPTION
Here's a fairly minimal example.

```
user> (let [conn (ds/create-conn {})]
        (ds/q '[:find ?n
                :where [(identity 1) ?n]
                       [(identity 2) ?n]]
              @conn))
#{[1]}
user>
```

The above should return the empty set `#{}`.

I've include two commits. One with a series of tests showing the failing cases followed by another which fixes the issue in the way which seems most reasonable. I'm interested to know if you concur with the fix.

When fixing this, I saw that `filter-by-pred` also uses `conj` instead of `collapse-rels`. This is likely fine since there are no bindings for predicates but I thought I'd mention it in passing.

Let me know if you'd like me to make any adjustments to this pull request!

-A.