### PR TITLE
Avoid keywordize attributes in schema->clj(closes #153)

### DIFF
--- a/src/datascript/js.cljs
+++ b/src/datascript/js.cljs
@@ -14,7 +14,8 @@
 
 (defn- schema->clj [schema]
   (->> (js->clj schema)
-       (walk/postwalk keywordize)))
+       (reduce-kv
+         (fn [m k v] (assoc m k (walk/postwalk keywordize v))) {})))
 
 (declare entities->clj)
 

--- a/test/js/tests.js
+++ b/test/js/tests.js
@@ -434,6 +434,28 @@ function test_filter() {
                              })));
 }
 
+function test_upsert() {
+  var schema = {
+    ":my/tid": {
+      ":db/unique": ":db.unique/identity"
+    }
+  };
+  var conn = d.create_conn(schema);
+
+  d.transact(conn, [{
+    ":my/tid": "5x",
+    ":my/name": "Terin"
+  }]);
+
+  d.transact(conn, [{
+    ":my/tid": "5x",
+    ":my/name": "Charlie"
+  }]);
+
+  var names = d.q('[:find ?name :where [?e ":my/tid" "5x"] [?e ":my/name" ?name]]', d.db(conn));
+  assert_eq_set([["Charlie"]], names);
+}
+
 function test_datascript_js() {
   return test_fns([ test_db_with,
                     test_nested_maps,
@@ -452,7 +474,8 @@ function test_datascript_js() {
                     test_q_fns,
                     test_find_specs,
                     test_datoms,
-                    test_filter
+                    test_filter,
+                    test_upsert
                   ]);
 }
 


### PR DESCRIPTION
Keywordize attributes in schema->clj looks like a bug(because in other functions you avoid convert user string to keyword). See: https://github.com/tonsky/datascript/issues/153#issuecomment-200723583.