### PR TITLE
Define db-with with comp

### DIFF
--- a/src/datascript/core.cljc
+++ b/src/datascript/core.cljc
@@ -58,9 +58,8 @@
                                :tempids   {}
                                :tx-meta   tx-meta}) tx-data))))
 
-(defn ^:export db-with [db tx-data]
-  {:pre [(db/db? db)]}
-  (:db-after (with db tx-data)))
+(def ^:export db-with
+  (comp :db-after with))
 
 (defn ^:export datoms
   ([db index]             {:pre [(db/db? db)]} (db/-datoms db index []))


### PR DESCRIPTION
This means you can also use db-with when you have tx-meta. The precondition shouldn't matter because with already has the same one.