### PR TITLE
Filter assertions concerning transaction entities when determining ma…

### DIFF
--- a/src/datascript/db.cljc
+++ b/src/datascript/db.cljc
@@ -586,13 +586,17 @@
                                          #js [] datoms)
                                  (.sort cmp-datoms-avet-quick))
                  avet    (btset/-btset-from-sorted-arr avet-datoms cmp-datoms-avet)
-                 max-eid (:e (first (-rseq eavt)))]
+                 max-eid     (:e (first (-rseq (btset/slice eavt
+                                                           (Datom. nil nil nil nil nil)
+                                                           (Datom. (dec tx0) nil nil nil nil)))))]
                 :clj
                 [eavt        (apply btset/btset-by cmp-datoms-eavt datoms)
                  aevt        (apply btset/btset-by cmp-datoms-aevt datoms)
                  avet-datoms (filter (fn [^Datom d] (contains? indexed (.-a d))) datoms)
                  avet        (apply btset/btset-by cmp-datoms-avet avet-datoms)
-                 max-eid     (:e (first (rseq eavt)))])
+                 max-eid     (:e (first (rseq (btset/slice eavt
+                                                           (Datom. nil nil nil nil nil)
+                                                           (Datom. (dec tx0) nil nil nil nil)))))])
             max-tx (transduce (map (fn [^Datom d] (.-tx d))) max tx0 eavt)]
         (map->DB {
           :schema  schema

--- a/test/datascript/test/serialization.cljc
+++ b/test/datascript/test/serialization.cljc
@@ -74,6 +74,8 @@
    [3 :follows 2]
    [3 :attach  { :another :map }]
    [3 :avatar  30]
+   [4 :name    "Nick" (+ d/tx0 100)]
+   [(+ d/tx0 100) :txInstant 0xdeadbeef]
    [30 :url    "https://" ]])
 
 
@@ -94,8 +96,13 @@
                         (d/init-db schema))
         db-transact (->> (map (fn [[e a v]] [:db/add e a v]) data)
                          (d/db-with (d/empty-db schema)))]
-    (testing "db-init produces the same result as regular transacttions"
+    (testing "db-init produces the same result as regular transactions"
       (is (= db-init db-transact)))
+
+    (testing "db-init produces the same max-eid as regular transactions"
+      (let [assertions [ [:db/add -1 :name "Lex"] ]]
+        (is (= (d/db-with db-init assertions)
+               (d/db-with db-transact assertions)))))
     
     (testing "Roundtrip"
       (doseq [[r read-fn] readers]


### PR DESCRIPTION
…x-eid. (closes #163)

This patch ensures that max-eid is not set into the transaction
partition if there are assertions about transaction ids in the initial
collection of datoms provided to db-init.

This means that replaying transactions yields a database identical in
all ways, including the max-eid field.