### PR TITLE
Var resolution for query fns/preds when in JVM

### DIFF
--- a/src/datascript/query.cljc
+++ b/src/datascript/query.cljc
@@ -430,10 +430,16 @@
                              args)]
       (apply f resolved-args))))
 
+(defn- resolve-sym [sym]
+  #?(:cljs nil
+     :clj (when (namespace sym)
+            (when-let [v (resolve sym)] @v))))
+
 (defn filter-by-pred [context clause]
   (let [[[f & args]] clause
         pred         (or (get built-ins f)
                          (context-resolve-val context f)
+                         (resolve-sym f)
                          (when (nil? (rel-with-attr context f))
                            (throw (ex-info (str "Unknown predicate '" f " in " clause)
                                            {:error :query/where, :form clause, :var f}))))
@@ -449,6 +455,7 @@
         binding  (dp/parse-binding out)
         fun      (or (get built-ins f)
                      (context-resolve-val context f)
+                     (resolve-sym f)
                      (when (nil? (rel-with-attr context f))
                        (throw (ex-info (str "Unknown function '" f " in " clause)
                                        {:error :query/where, :form clause, :var f}))))

--- a/test/datascript/test/query_fns.cljc
+++ b/test/datascript/test/query_fns.cljc
@@ -259,3 +259,13 @@
            :where [(fun ?e) ?x]]
          [1]))))
 
+(def sample-query-fn (constantly 42))
+
+(deftest test-symbol-resolution
+  (let [q '[:find ?x .
+            :where [(datascript.test.query-fns/sample-query-fn) ?x]]]
+    #?(:clj
+       (is (= 42 (d/q q [1])))
+       :cljs
+       (is (thrown-with-msg? ExceptionInfo #"Unknown function"
+             (d/q q [1]))))))


### PR DESCRIPTION
This commit adds a reader conditional to enable the use of
namespace-qualified symbols as query functions or predicates, when in
JVM Clojure. This allows queries using functions or predicates to be
reused between Datomic and DataScript when running on the JVM.

The semantics of a DataScript query are otherwise unchanged; global var
resolution is only attempted as a final step before failure.

The semantics when operating in a ClojureScript context are entirely
unchanged, since global symbol->var resolution is not supported.