### PR TITLE
Added installed transaction functions using :db/ident and :db/fn semantics

### DIFF
--- a/src/datascript/db.cljc
+++ b/src/datascript/db.cljc
@@ -1109,8 +1109,8 @@
               (and (ref? db a) (tx-id? v))
                 (recur (allocate-eid report v (current-tx report)) (cons [op e a (current-tx report)] entities))
 
-              (tempid? e)
-                (if (not= op :db/add)
+              (and (tempid? e) (some #(= op %) [:db/add :db.fn/call :db.fn/cas :db/cas :db/retract :db.fn/retractAttribute :db.fn/retractEntity]))
+                (if (some #(= op %) [:db.fn/call :db.fn/cas :db/cas :db/retract :db.fn/retractAttribute :db.fn/retractEntity])
                   (raise "Tempids are resolved for :db/add only"
                          { :error :transact/syntax
                            :op    entity })
@@ -1158,8 +1158,13 @@
                   (recur report entities))
 
              :else
-               (raise "Unknown operation at " entity ", expected :db/add, :db/retract, :db.fn/call, :db.fn/retractAttribute or :db.fn/retractEntity"
-                      {:error :transact/syntax, :operation op, :tx-data entity})))
+             (let [[ident & args] entity]
+               (let [{e :e v :v} (first (-datoms db :avet [:db/ident ident]))
+                     f (:v (first (-search db [e :db/fn])))]
+                 (if (and (= v ident) (fn? f))
+                   (recur report (concat (apply f db args) entities))
+                   (raise "Unknown operation at " entity ", expected :db/add, :db/retract, :db.fn/call, :db.fn/retractAttribute, :db.fn/retractEntity or an ident corresponding to an installed transaction function (e.g. {:db/ident <keyword> :db/fn <Ifn>}, usage of :db/ident requires {:db/unique :db.unique/identity} in schema)"
+                          {:error :transact/syntax, :operation op, :tx-data entity}))))))
        
        (datom? entity)
          (let [[e a v tx added] entity]


### PR DESCRIPTION
The existing approach uses function references with :db.fn/call which meant I couldn't trivially serialise  (using transit/write) tx-data before expansion into datoms, so I created this alternative which should also enable some interesting new patterns for function modularity. I appreciate it's probably not "native" enough to be accepted as-is, but what do you think? Do you see a better way?
