### PR TITLE
Built in vector, hash-map

### DIFF
--- a/src/datascript/query.cljc
+++ b/src/datascript/query.cljc
@@ -158,7 +158,8 @@
   'count count, 'range range, 'not-empty not-empty, 'empty? empty,
   'str str, 'pr-str pr-str, 'print-str print-str, 'println-str println-str, 'prn-str prn-str, 'subs subs,
   're-find re-find, 're-matches re-matches, 're-seq re-seq,
-  '-differ? -differ?, 'get-else -get-else, 'get-some -get-some, 'missing? -missing?, 'ground identity})
+  '-differ? -differ?, 'get-else -get-else, 'get-some -get-some, 'missing? -missing?, 'ground identity
+  'vector vector 'hash-map hash-map})
  
 (def built-in-aggregates 
  (letfn [(sum [coll] (reduce + 0 coll))

--- a/test/datascript/test/query_fns.cljc
+++ b/test/datascript/test/query_fns.cljc
@@ -72,6 +72,19 @@
                    ["a" "abc"])
              #{["a" 1] ["abc" 3]})))
 
+    (testing "Built-in vector, hashmap"
+      (is (= (d/q '[:find [?tx-data ...]
+                    :where
+                    [(ground :db/add) ?op]
+                    [(vector ?op :attr 12) ?tx-data]])
+             [[:db/add :attr 12]]))
+
+      (is (= (d/q '[:find [?tx-data ...]
+                    :where
+                    [(hash-map :db/id -1 :age 92 :name "Aaron") ?tx-data]])
+             [{:db/id -1 :age 92 :name "Aaron"}])))
+
+
     (testing "Passing predicate as source"
       (is (= (q/q '[:find  ?e
                     :in    $ ?adult

--- a/test/datascript/test/query_fns.cljc
+++ b/test/datascript/test/query_fns.cljc
@@ -76,8 +76,8 @@
       (is (= (d/q '[:find [?tx-data ...]
                     :where
                     [(ground :db/add) ?op]
-                    [(vector ?op :attr 12) ?tx-data]])
-             [[:db/add :attr 12]]))
+                    [(vector ?op -1 :attr 12) ?tx-data]])
+             [[:db/add -1 :attr 12]]))
 
       (is (= (d/q '[:find [?tx-data ...]
                     :where


### PR DESCRIPTION
I'm missing `vector` and `hash-map` as built in functions. I find them useful to construct new data structures that could be transacted, usually in combination with rules. The tests are meant to give a hint of how this could be useful.