### PR TITLE
False in cached entity values

### DIFF
--- a/src/datascript/impl/entity.cljc
+++ b/src/datascript/impl/entity.cljc
@@ -161,14 +161,15 @@
      (.-eid this)
      (if (db/reverse-ref? attr)
        (-lookup-backwards (.-db this) (.-eid this) (db/reverse-ref attr) not-found)
-       (or (@(.-cache this) attr)
-           (if @(.-touched this)
-             not-found
-             (if-let [datoms (not-empty (db/-search (.-db this) [(.-eid this) attr]))]
-               (let [value (entity-attr (.-db this) attr datoms)]
-                 (vreset! (.-cache this) (assoc @(.-cache this) attr value))
-                 value)
-               not-found)))))))
+       (if-let [[_ v] (find @(.-cache this) attr)]
+         v
+         (if @(.-touched this)
+           not-found
+           (if-let [datoms (not-empty (db/-search (.-db this) [(.-eid this) attr]))]
+             (let [value (entity-attr (.-db this) attr datoms)]
+               (vreset! (.-cache this) (assoc @(.-cache this) attr value))
+               value)
+             not-found)))))))
 
 (defn touch-components [db a->v]
   (reduce-kv (fn [acc a v]

--- a/test/datascript/test/core.cljc
+++ b/test/datascript/test/core.cljc
@@ -58,14 +58,15 @@
   (let [schema {:aka {:db/cardinality :db.cardinality/many}}
         db (d/db-with (d/empty-db schema)
                       [{:db/id 1 :name "Ivan" :aka ["IV" "Terrible"]}
-                       {:db/id 2 :name "Petr" :age 37}])]
+                       {:db/id 2 :name "Petr" :age 37 :huh? false}])]
     (is (= (d/empty-db schema)
            (empty db)))
-    (is (= 5 (count db)))
-    (is (= (vec (seq db))
-           [(d/datom 1 :aka "IV")
-            (d/datom 1 :aka "Terrible")
-            (d/datom 1 :name "Ivan")
-            (d/datom 2 :age 37)
-            (d/datom 2 :name "Petr")]))
+    (is (= 6 (count db)))
+    (is (= (set (seq db))
+           #{(d/datom 1 :aka "IV")
+             (d/datom 1 :aka "Terrible")
+             (d/datom 1 :name "Ivan")
+             (d/datom 2 :age 37)
+             (d/datom 2 :name "Petr")
+             (d/datom 2 :huh? false)}))
     ))

--- a/test/datascript/test/entity.cljc
+++ b/test/datascript/test/entity.cljc
@@ -14,7 +14,8 @@
 (deftest test-entity
   (let [db (-> (d/empty-db {:aka {:db/cardinality :db.cardinality/many}})
                (d/db-with [{:db/id 1, :name "Ivan", :age 19, :aka ["X" "Y"]}
-                           {:db/id 2, :name "Ivan", :sex "male", :aka ["Z"]}]))
+                           {:db/id 2, :name "Ivan", :sex "male", :aka ["Z"]}
+                           [:db/add 3 :huh? false]]))
         e  (d/entity db 1)]
     (is (= (:db/id e) 1))
     (is (identical? (d/entity-db e) db))
@@ -30,6 +31,9 @@
            {:name "Ivan", :age 19, :aka #{"X" "Y"}}))
     (is (= (into {} (d/entity db 2))
            {:name "Ivan", :sex "male", :aka #{"Z"}}))
+    (let [e3 (d/entity db 3)]
+      (is (= (into {} e3) {:huh? false})) ; Force caching.
+      (is (false? (:huh? e3))))
 
     (is (= (pr-str (d/entity db 1)) "{:db/id 1}"))
     (is (= (pr-str (let [e (d/entity db 1)] (:unknown e) e)) "{:db/id 1}"))


### PR DESCRIPTION
I discovered this with some debugging code like this:

```clojure
(prn (into {} ev) (:event/ok? ev))
```

And it was printing something like:

```clojure
{:event/ok? false} nil
```

Confusingly, if I omitted that debug print statement, `(:event/ok? ev)` returned false. Subsequent calls, however, returned `nil`.

The first commit in this PR isolates the problem to incorrect logical-false handling in the entity value cache. The second commit fixes it.