### PR TITLE
More valid schema value types.

### DIFF
--- a/src/datascript/db.cljc
+++ b/src/datascript/db.cljc
@@ -554,7 +554,10 @@
                          :attribute a
                          :key       :db/isComponent}))))
     (validate-schema-key a :db/unique (:db/unique kv) #{:db.unique/value :db.unique/identity})
-    (validate-schema-key a :db/valueType (:db/valueType kv) #{:db.type/ref})
+    (validate-schema-key a :db/valueType (:db/valueType kv) #{:db.type/ref :db.type/string
+                                                              :db.type/long :db.type/keyword
+                                                              :db.type/boolean :db.type/int
+                                                              :db.type/float :db.type/instant})
     (validate-schema-key a :db/cardinality (:db/cardinality kv) #{:db.cardinality/one :db.cardinality/many}))
   schema)
 


### PR DESCRIPTION
This commit adds more schema value types, even though Datascript doesn't care about the type other than if it's a `:db.type/ref` or not.  The value type keywords follow closely with Datomic.

This allows using a schema defined for Datascript to drive schemas for other databases that care more about type such as Datomic or ElasticSearch.

If it is preferred that `:db.type/ref` is the only valid type, we could instead have that refer to a `def`'ed value containing a set of `:db.type/ref`.  This would allow monkey-patching by other modules by redefining the value.