### PR TITLE
use `Object` explicitly with `into-array` so btset can accept members of different types

### DIFF
--- a/src/datascript/btset.cljc
+++ b/src/datascript/btset.cljc
@@ -229,7 +229,7 @@
              i   1
              p   (da/aget arr 0)]
         (if (>= i al)
-          (into-array (persistent! acc)) ;; TODO avoid persistent?
+          (into-array Object (persistent! acc)) ;; TODO avoid persistent?
           (let [e (da/aget arr i)]
             (if (== 0 (cmp e p))
               (recur acc (inc i) e)
@@ -1006,7 +1006,7 @@
                (+ shift level-shift))))))
 
 (defn -btset-from-seq [seq cmp] ;; TODO avoid array?
-  (let [arr (-> seq into-array (da/asort cmp) (sorted-arr-distinct cmp))]
+  (let [arr (-> (into-array Object seq) (da/asort cmp) (sorted-arr-distinct cmp))]
     (-btset-from-sorted-arr arr cmp)))
 
 (defn btset-by


### PR DESCRIPTION
This might not currently be relevant to datascript broadly, but does make btset more generally useful.