### PR TITLE
fix externs.js and the exported symbols

### DIFF
--- a/src/datascript/db.cljc
+++ b/src/datascript/db.cljc
@@ -183,6 +183,8 @@
         (assoc [d k v] (assoc-datom d k v))
         ]))
 
+#?(:cljs (goog/exportSymbol "datascript.db.Datom" Datom))
+
 (defn ^Datom datom
   ([e a v]          (Datom. e a v tx0 true))
   ([e a v tx]       (Datom. e a v tx true))

--- a/src/datascript/externs.js
+++ b/src/datascript/externs.js
@@ -1,18 +1,26 @@
 var datascript = {};
 datascript.db = {};
-datascript.db.Datom = {};
-datascript.db.Datom.e = 0;
-datascript.db.Datom.a = "";
-datascript.db.Datom.v = "";
-datascript.db.Datom.tx = 0;
-datascript.db.Datom.added = true;
+
+/**
+ * @constructor
+ */
+datascript.db.Datom = function() {};
+datascript.db.Datom.prototype.e;
+datascript.db.Datom.prototype.a;
+datascript.db.Datom.prototype.v;
+datascript.db.Datom.prototype.tx;
+datascript.db.Datom.prototype.added;
+
 
 datascript.impl = {};
 datascript.impl.entity = {};
-datascript.impl.entity.Entity = {};
-datascript.impl.entity.Entity.db = {};
-datascript.impl.entity.Entity.eid = {};
 
+/**
+ * @constructor
+ */
+datascript.impl.entity.Entity = function() {};
+datascript.impl.entity.Entity.prototype.db;
+datascript.impl.entity.Entity.prototype.eid;
 datascript.impl.entity.Entity.prototype.keys      = function() {};
 datascript.impl.entity.Entity.prototype.entries   = function() {};
 datascript.impl.entity.Entity.prototype.values    = function() {};

--- a/src/datascript/impl/entity.cljc
+++ b/src/datascript/impl/entity.cljc
@@ -202,17 +202,4 @@
       (vreset! (.-touched e) true)))
   e)
 
-#?(:cljs (do
-           (goog/exportSymbol "datascript.impl.entity.Entity.prototype.get"       (.-get       (.-prototype Entity)))
-           (goog/exportSymbol "datascript.impl.entity.Entity.prototype.has"       (.-has       (.-prototype Entity)))
-           (goog/exportSymbol "datascript.impl.entity.Entity.prototype.forEach"   (.-forEach   (.-prototype Entity)))
-           (goog/exportSymbol "datascript.impl.entity.Entity.prototype.key_set"   (.-key_set   (.-prototype Entity)))
-           (goog/exportSymbol "datascript.impl.entity.Entity.prototype.value_set" (.-value_set (.-prototype Entity)))
-           (goog/exportSymbol "datascript.impl.entity.Entity.prototype.entry_set" (.-entry_set (.-prototype Entity)))
-           (goog/exportSymbol "datascript.impl.entity.Entity.prototype.keys"      (.-keys      (.-prototype Entity)))
-           (goog/exportSymbol "datascript.impl.entity.Entity.prototype.values"    (.-values    (.-prototype Entity)))
-           (goog/exportSymbol "datascript.impl.entity.Entity.prototype.entries"   (.-entries   (.-prototype Entity)))
-
-           (goog/exportSymbol "cljs.core.ES6Iterator.prototype.next"        (.-next (.-prototype cljs.core/ES6Iterator)))
-           (goog/exportSymbol "cljs.core.ES6EntriesIterator.prototype.next" (.-next (.-prototype cljs.core/ES6EntriesIterator)))
-           ))
+#?(:cljs (goog/exportSymbol "datascript.impl.entity.Entity" Entity))


### PR DESCRIPTION
The `datascript/externs.js` is written incorrectly.

Including the externs via `deps.cljs` means that CLJS projects can never rename them as well which  isn't useful. CLJS projects that want to use this would be better off without the externs/exports.

You should consider only using the externs/exports when building the JS lib.