### PR TITLE
Fixed deref of nested structures

### DIFF
--- a/src/datascript/js.cljs
+++ b/src/datascript/js.cljs
@@ -19,11 +19,14 @@
 
 (defn- ^:declared entities->clj [entities])
 
+(defn- keywordize-db-id [e]
+  (let [f (fn [[k v]] (if (= ":db/id" k) [:db/id v] [k v]))]
+    (walk/postwalk (fn [x] (if (map? x) (into {} (map f x)) x)) e)))
+
 (defn- entity->clj [e]
-  (cond (map? e)
-    (-> e
-      (dissoc ":db/id")
-      (assoc  :db/id (e ":db/id")))
+  (cond
+    (map? e)
+      (keywordize-db-id e)
     (= (first e) ":db.fn/call")
       (let [[_ f & args] e]
         (concat [:db.fn/call (fn [& args] (entities->clj (apply f args)))] args))

--- a/test/js/tests.js
+++ b/test/js/tests.js
@@ -348,6 +348,17 @@ function test_resolve_current_tx() {
     d.datoms(d.db(conn), ":eavt"));
 }
 
+function test_is_component() {
+
+  var db = d.db_with(d.empty_db({"aka": {":db/valueType": ":db.type/ref",
+                                         ":db/cardinality": ":db.cardinality/one",
+                                         ":db/isComponent": true}}),
+                     [{ ":db/id": 1, "name": "Ivan" },
+                      { ":db/id": 2, "name": "X" },
+                      { ":db/id": 1, "aka": {":db/id": 2 }}]);
+
+  assert_eq({":db/id":1,"aka":{":db/id":2,"name":"X"},"name":"Ivan"}, d.pull(db, "[*]", 1));
+}
 
 var people_db = d.db_with(d.empty_db({"age": {":db/index": true}}),
                  [{ ":db/id": 1, "name": "Ivan", "age": 15 },
@@ -497,6 +508,7 @@ function test_datascript_js() {
                     test_pull,
                     test_lookup_refs,
                     test_resolve_current_tx,
+                    test_is_component,
                     test_q_coll,
                     test_q_relation,
                     test_q_rules,


### PR DESCRIPTION
Currently the JS version doesn't support dereferencing of existing attributes in a map form, e.g. on schema 
```
{"aka": {":db/valueType": ":db.type/ref", ":db/cardinality": ":db.cardinality/one"}}
``` 
transact with 
```
{ ":db/id": 1, "name": "Ivan" }, { ":db/id": 2, "name": "X" }, { ":db/id": 1, "aka": {":db/id": 2 }}
``` 
will result not in 2 entities, but 3 (one being created automatically by `db/transact-tx-data` since there is a check for :db/id as a keyword, but not as a string).
IMHO the reason is that only the :db/id on the main entity gets replaced by `js/entity->clj` and it doesn't happen recursively for the nested entities.
