### PR TITLE
GH-219 Type hints all primitives for the :declared vars

### DIFF
--- a/src/datascript/btset.cljc
+++ b/src/datascript/btset.cljc
@@ -692,14 +692,14 @@
   (-prev-path (.-root set) path (.-shift set)))
 
 ;; using defn instead of declare because of http://dev.clojure.org/jira/browse/CLJS-1871 
-(defn ^:declared iter [set left right])
+(defn ^:declared iter [set ^long left ^long right])
 (defn ^:declared iter-first [iter])
 (defn ^:declared iter-next [iter])
 (defn ^:declared iter-chunk [iter])
 (defn ^:declared iter-chunked-next [iter])
 (defn ^:declared iter-rseq [iter])
 (defn ^:declared iter-reduce ([iter f]) ([iter f start]))
-(defn ^:declared riter [set left right])
+(defn ^:declared riter [set ^long left ^long right])
 (defn ^:declared riter-first [riter])
 (defn ^:declared riter-next [ri])
 (defn ^:declared riter-rseq [riter])

--- a/src/datascript/db.cljc
+++ b/src/datascript/db.cljc
@@ -121,7 +121,7 @@
 (defn- ^:declared hash-datom [d])
 (defn- ^:declared equiv-datom [a b])
 (defn- ^:declared seq-datom [d])
-(defn- ^:declared nth-datom ([d i]) ([d i nf]))
+(defn- ^:declared nth-datom ([d ^long i]) ([d ^long i nf]))
 (defn- ^:declared assoc-datom [d k v])
 (defn- ^:declared val-at-datom [d k nf])
 


### PR DESCRIPTION
Adds primitive type hints to `^:declared` defns.

#219 