### PR TITLE
added the ability to use keyword refs directly as entity ids

### DIFF
--- a/src/datascript/impl/entity.cljc
+++ b/src/datascript/impl/entity.cljc
@@ -12,7 +12,8 @@
 
 (defn- entid [db eid]
   (when (or (number? eid)
-            (sequential? eid))
+            (sequential? eid)
+            (keyword? eid))
     (db/entid db eid)))
 
 (defn entity [db eid]

--- a/src/datascript/query.cljc
+++ b/src/datascript/query.cljc
@@ -145,7 +145,7 @@
 (defn- and-fn [& args]
   (reduce (fn [a b]
             (if b b (reduced b))) true args))
-            
+
 (defn- or-fn [& args]
   (reduce (fn [a b]
             (if b (reduced b) b)) nil args))
@@ -163,8 +163,8 @@
   'str str, 'pr-str pr-str, 'print-str print-str, 'println-str println-str, 'prn-str prn-str, 'subs subs,
   're-find re-find, 're-matches re-matches, 're-seq re-seq,
   '-differ? -differ?, 'get-else -get-else, 'get-some -get-some, 'missing? -missing?, 'ground identity})
- 
-(def built-in-aggregates 
+
+(def built-in-aggregates
  (letfn [(sum [coll] (reduce + 0 coll))
          (avg [coll] (/ (sum coll) (count coll)))
          (median
@@ -183,8 +183,8 @@
                                  :let [delta (- x mean)]]
                              (* delta delta)))]
              (/ sum (count coll))))
-         (stddev 
-           [coll] 
+         (stddev
+           [coll]
            (#?(:cljs js/Math.sqrt :clj Math/sqrt) (variance coll)))]
    {'avg      avg
     'median   median
@@ -249,11 +249,11 @@
   BindIgnore
   (in->rel [_ _]
     (prod-rel))
-  
+
   BindScalar
   (in->rel [binding value]
     (Relation. {(get-in binding [:variable :symbol]) 0} [(into-array [value])]))
-  
+
   BindColl
   (in->rel [binding coll]
     (cond
@@ -265,7 +265,7 @@
       :else
         (reduce sum-rel
           (map #(in->rel (:binding binding) %) coll))))
-  
+
   BindTuple
   (in->rel [binding coll]
     (cond
@@ -430,7 +430,7 @@
         tuples-args (da/make-array len)]
     (dotimes [i len]
       (let [arg (nth args i)]
-        (if (symbol? arg) 
+        (if (symbol? arg)
           (if-let [source (get sources arg)]
             (da/aset static-args i source)
             (da/aset tuples-args i (get attrs arg)))
@@ -596,9 +596,9 @@
   (if (satisfies? db/IDB source)
     (let [[e a v tx] pattern]
       (->
-        [(if (lookup-ref? e) (db/entid-strict source e) e)
+        [(if (or (lookup-ref? e) (attr? e)) (db/entid-strict source e) e)
          a
-         (if (and v (attr? a) (db/ref? source a) (lookup-ref? v)) (db/entid-strict source v) v)
+         (if (and v (attr? a) (db/ref? source a) (or (lookup-ref? v) (attr? v))) (db/entid-strict source v) v)
          (if (lookup-ref? tx) (db/entid-strict source tx) tx)]
         (subvec 0 (count pattern))))
     pattern))

--- a/test/datascript/test/entity.cljc
+++ b/test/datascript/test/entity.cljc
@@ -86,7 +86,8 @@
                          {:db/id 2, :name "Oleg"}]))]
     (is (nil? (d/entity db nil)))
     (is (nil? (d/entity db "abc")))
-    (is (nil? (d/entity db :keyword)))
+    ;;(is (nil? (d/entity db :keyword)))
+    (is (thrown-with-msg? ExceptionInfo #"You must have :db/ident marked as :db/unique in your schema to use keyword refs" (d/entity db :keyword)))
     (is (nil? (d/entity db [:name "Petr"])))
     (is (= 777 (:db/id (d/entity db 777))))
     (is (thrown-with-msg? ExceptionInfo #"Lookup ref attribute should be marked as :db/unique"


### PR DESCRIPTION
This is a more modest update than tx-middleware. It is an important piece for syncing schema between different databases. This would be too difficult to do outside of datascript.
  
All it is doing is translating `:keyword` used in eid positions to `[:db/ident :keyword]` style lookup-refs before resolving. It will error if you don't have `:db/ident` in your schema.