### PR TITLE
fix: wrong Java equals for Entity

### DIFF
--- a/src/datascript/impl/entity.cljc
+++ b/src/datascript/impl/entity.cljc
@@ -124,6 +124,7 @@
       [Object
        (toString [e]      (pr-str (assoc @cache :db/id eid)))
        (hashCode [e]      (hash eid)) ; db?
+       (equals [e o]      (equiv-entity e o))
 
        clojure.lang.Seqable
        (seq [e]           (touch e) (seq @cache))


### PR DESCRIPTION
Hey Nikita,
First of all thanks for this wonderful library. I started using it recently and I am loving it :)

I am using Datascript with together with some Java code (HashMaps and Heaps) for which Java uses their own `equals` method instead of Clojure's `equiv`. This of course causes several problems from my side due to two entities being equivalent but not equal (comparing memory location not values).

Let me know if I am overlooking something or if this is a quick fix as I think.

Hope it helps