### PR TITLE
index-range on unindexed attr throws ClassCastException instead of assertion with actual cause

### DIFF
--- a/src/datascript/db.cljc
+++ b/src/datascript/db.cljc
@@ -457,7 +457,7 @@
 
   (-index-range [db attr start end]
     (when-not (indexing? db attr)
-      (raise "Attribute" attr "should be marked as :db/index true"))
+      (raise "Attribute" attr "should be marked as :db/index true" {}))
     (validate-attr attr (list '-index-range 'db attr start end))
     (btset/slice (.-avet db) (resolve-datom db nil attr start nil)
                  (resolve-datom db nil attr end nil))))


### PR DESCRIPTION
 
 (require '[datascript.core :as ds])
  (db/index-range (ds/empty-db) ::foo 0 0)
  =>
  Unhandled java.lang.ClassCastException
   java.lang.String cannot be cast to clojure.lang.IPersistentMap

                  core.clj: 4725  clojure.core/ex-info
                  core.clj: 4725  clojure.core/ex-info
                   db.cljc:  394  datascript.db.DB/_index_range
                 core.cljc:  106  datascript.core$index_range/invokeStatic
                 core.cljc:  104  datascript.core$index_range/invoke
                   db.cljc:  237  onair.db$index_range/invokeStatic
                   db.cljc:  235  onair.db$index_range/invoke
