### PR TITLE
Optimize memory usage of Datom type

### DIFF
--- a/bench/project.clj
+++ b/bench/project.clj
@@ -1,7 +1,7 @@
 (defproject datascript-bench "0.1.0"
   :dependencies [
-    [org.clojure/clojure "1.7.0-RC1"]
-    [org.clojure/clojurescript "0.0-3308"]
+    [org.clojure/clojure "1.9.0"]
+    [org.clojure/clojurescript "1.10.217"]
     [datascript ~(or (System/getenv "BENCH_VERSION") "0.11.4")]
     [com.datomic/datomic-free ~(or (System/getenv "DATOMIC_VERSION") "0.9.5173")
       :exclusions [joda-time]]

--- a/project.clj
+++ b/project.clj
@@ -7,6 +7,8 @@
   :dependencies [
     [org.clojure/clojure "1.7.0" :scope "provided"]
     [org.clojure/clojurescript "1.7.228" :scope "provided"]
+   ;[org.clojure/clojure "1.9.0"]
+   ;[org.clojure/clojurescript "1.10.217"]
   ]
   
   :plugins [
@@ -30,7 +32,7 @@
                                  ["run" "-m" "datascript.test/test-node" "--all"]]
             "test-1.8"     ["with-profile" "dev,1.8" "test-all"]
             "test-1.9"     ["with-profile" "dev,1.9" "test-all"]}
-  
+
   :cljsbuild { 
     :builds [
       { :id "release"

--- a/src/datascript/impl/entity.cljc
+++ b/src/datascript/impl/entity.cljc
@@ -1,7 +1,8 @@
 (ns datascript.impl.entity
   (:refer-clojure :exclude [keys get])
   (:require [#?(:cljs cljs.core :clj clojure.core) :as c]
-            [datascript.db :as db]))
+            [datascript.db :as db])
+  #?(:clj (:import [datascript.db DB])))
 
 (declare entity ->Entity equiv-entity lookup-entity touch)
 
@@ -182,11 +183,12 @@
                    v)))
              {} a->v))
 
-(defn- datoms->cache [db datoms]
-  (reduce (fn [acc part]
-    (let [a (:a (first part))]
-      (assoc acc a (entity-attr db a part))))
-    {} (partition-by :a datoms)))
+(defn- datoms->cache [^DB db datoms]
+  (let [^objects attrs (.-attrs db)]
+    (reduce (fn [acc part]
+             (let [a (aget attrs (:a (first part)))]
+               (assoc acc a (entity-attr db a part))))
+           {} (partition-by :a datoms))))
 
 (defn touch [^Entity e]
   {:pre [(entity? e)]}

--- a/src/datascript/js.cljs
+++ b/src/datascript/js.cljs
@@ -4,7 +4,8 @@
     [goog.object :as go]
     [datascript.core :as d]
     [clojure.walk :as walk]
-    [cljs.reader]))
+    [cljs.reader]
+    [datascript.db :as db]))
 
 ;; Conversions
 
@@ -52,7 +53,7 @@
 (defn js->Datom [d]
   (if (array? d)
     (d/datom (aget d 0) (aget d 1) (aget d 2) (or (aget d 3) d/tx0) (or (aget d 4) true))
-    (d/datom (.-e d) (.-a d) (.-v d) (or (.-tx d) d/tx0) (or (.-added d) true))))
+    (d/datom (db/-e d) (db/-a d) (.-v d) (or (db/-tx d) d/tx0) (or (db/-added d) true))))
 
 (defn- pull-result->js
   [result]

--- a/src/datascript/query.cljc
+++ b/src/datascript/query.cljc
@@ -30,7 +30,7 @@
 ;;    {?e 0, ?v 1} or {?e2 "a", ?age "v"}
 ;; tuples:
 ;;    [ #js [1 "Ivan" 5 14] ... ]
-;; or [ (Datom. 2 "Oleg" 1 55) ... ]
+;; or [ (datom 2 "Oleg" 1 55) ... ]
 (defrecord Relation [attrs tuples])
 
 
@@ -87,9 +87,9 @@
         l2  (alength idxs2)
         res (da/make-array (+ l1 l2))]
     (dotimes [i l1]
-      (aset res i (#?(:cljs da/aget :clj get) t1 (aget idxs1 i)))) ;; FIXME aget
+      (aset res i (get t1 (aget idxs1 i)))) ;; FIXME aget
     (dotimes [i l2]
-      (aset res (+ l1 i) (#?(:cljs da/aget :clj get) t2 (aget idxs2 i)))) ;; FIXME aget
+      (aset res (+ l1 i) (get t2 (aget idxs2 i)))) ;; FIXME aget
     res))
 
 (defn sum-rel [a b]
@@ -301,14 +301,14 @@
     (if (and (not (nil? *lookup-attrs*))
              (contains? *lookup-attrs* attr))
       (fn [tuple]
-        (let [eid (#?(:cljs da/aget :clj get) tuple idx)]
+        (let [eid (get tuple idx)]
           (cond
             (number? eid)     eid ;; quick path to avoid fn call
             (sequential? eid) (db/entid *lookup-source* eid)
             (da/array? eid)   (db/entid *lookup-source* eid)
             :else             eid)))
       (fn [tuple]
-        (#?(:cljs da/aget :clj get) tuple idx)))))
+        (get tuple idx)))))
 
 (defn tuple-key-fn [getters]
   (if (== (count getters) 1)
@@ -410,7 +410,7 @@
 (defn- context-resolve-val [context sym]
   (when-let [rel (rel-with-attr context sym)]
     (when-let [tuple (first (:tuples rel))]
-      (#?(:cljs da/aget :clj get) tuple ((:attrs rel) sym)))))
+      (get tuple ((:attrs rel) sym)))))
 
 (defn- rel-contains-attrs? [rel attrs]
   (not (empty? (set/intersection (set attrs) (set (keys (:attrs rel)))))))
@@ -437,7 +437,7 @@
       ;; TODO raise if not all args are bound
       (dotimes [i len]
         (when-let [tuple-idx (aget tuples-args i)]
-          (let [v (#?(:cljs da/aget :clj get) tuple tuple-idx)]
+          (let [v (get tuple tuple-idx)]
             (da/aset static-args i v))))
       (apply f static-args))))
 
@@ -659,7 +659,7 @@
                      (let [res (aclone t1)]
                        (dotimes [i len]
                          (when-let [idx (aget copy-map i)]
-                           (aset res i (#?(:cljs da/aget :clj get) t2 idx))))
+                           (aset res i (get t2 idx))))
                        res))
                    (next rels)
                    symbols))))

--- a/src/datascript/query_v3.cljc
+++ b/src/datascript/query_v3.cljc
@@ -18,7 +18,7 @@
         Constant DefaultSrc Pattern RulesVar SrcVar Variable
         Not Or And Predicate PlainSymbol]
       [clojure.lang     IReduceInit Counted]
-      [datascript.db  Datom]
+      [datascript.db Datom]
       [datascript.btset Iter])))
 
 (declare resolve-clauses collect-rel-xf collect-to)

--- a/test/datascript/test/conn.cljc
+++ b/test/datascript/test/conn.cljc
@@ -6,9 +6,12 @@
     [datascript.db :as db]
     [datascript.test.core :as tdc]))
 
-(def schema { :aka { :db/cardinality :db.cardinality/many }})
-(def datoms #{(d/datom 1 :age  17)
-              (d/datom 1 :name "Ivan")})
+(def schema { :aka { :db/cardinality :db.cardinality/many :db/order 0 }
+             :name {:db/order 1}
+             :age {:db/order 2}
+             :sex {:db/order 3}})
+(def datoms #{(d/datom 1 0  17)
+              (d/datom 1 1 "Ivan")})
 
 (deftest test-ways-to-create-conn
   (let [conn (d/create-conn)]
@@ -39,8 +42,8 @@
   (let [conn    (d/conn-from-datoms datoms schema)
         report  (atom nil)
         _       (d/listen! conn #(reset! report %))
-        datoms' #{(d/datom 1 :age 20)
-                  (d/datom 1 :sex :male)}
+        datoms' #{(d/datom 1 2 20)
+                  (d/datom 1 3 :male)}
         schema' { :email { :db/unique :db.unique/identity }}
         db'     (d/init-db datoms' schema')]
     (d/reset-conn! conn db' :meta)
@@ -53,10 +56,10 @@
       (is (= datoms' (set (d/datoms db-after :eavt))))
       (is (= schema' (:schema db-after)))
       (is (= :meta   tx-meta))
-      (is (= [[1 :age  17     false]
-              [1 :name "Ivan" false]
-              [1 :age  20     true]
-              [1 :sex  :male  true]]
-             (map (juxt :e :a :v :added) tx-data))))))
+      (is (= [[1 0  17     false]
+              [1 1 "Ivan" false]
+              [1 2  20     true]
+              [1 3  :male  true]]
+             (mapv (juxt :e :a :v :added) tx-data))))))
   
   

--- a/test/datascript/test/core.cljc
+++ b/test/datascript/test/core.cljc
@@ -55,7 +55,11 @@
 ;; Core tests
 
 (deftest test-protocols
-  (let [schema {:aka {:db/cardinality :db.cardinality/many}}
+  (let [schema {:aka {:db/cardinality :db.cardinality/many
+                      :db/order 0}
+                :name {:db/order 1}
+                :age {:db/order 2}
+                :huh? {:db/order 3}}
         db (d/db-with (d/empty-db schema)
                       [{:db/id 1 :name "Ivan" :aka ["IV" "Terrible"]}
                        {:db/id 2 :name "Petr" :age 37 :huh? false}])]
@@ -63,10 +67,10 @@
            (empty db)))
     (is (= 6 (count db)))
     (is (= (set (seq db))
-           #{(d/datom 1 :aka "IV")
-             (d/datom 1 :aka "Terrible")
-             (d/datom 1 :name "Ivan")
-             (d/datom 2 :age 37)
-             (d/datom 2 :name "Petr")
-             (d/datom 2 :huh? false)}))
+           #{(d/datom 1 0 "IV")
+             (d/datom 1 0 "Terrible")
+             (d/datom 1 1 "Ivan")
+             (d/datom 2 2 37)
+             (d/datom 2 1 "Petr")
+             (d/datom 2 3 false)}))
     ))

--- a/test/datascript/test/entity.cljc
+++ b/test/datascript/test/entity.cljc
@@ -12,7 +12,14 @@
 
 
 (deftest test-entity
-  (let [db (-> (d/empty-db {:aka {:db/cardinality :db.cardinality/many}})
+  (let [db (-> (d/empty-db {:aka  {:db/cardinality :db.cardinality/many
+                                   :db/order       0}
+                            :name {:db/order 1}
+                            :age  {:db/order 2}
+                            :huh? {:db/order 3}
+                            :sex  {:db/order 4}
+                            :not-found {:db/order 5}
+                            :unknown {:db/order 6}})
                (d/db-with [{:db/id 1, :name "Ivan", :age 19, :aka ["X" "Y"]}
                            {:db/id 2, :name "Ivan", :sex "male", :aka ["Z"]}
                            [:db/add 3 :huh? false]]))
@@ -42,9 +49,11 @@
            (edn/read-string "{:name \"Ivan\", :db/id 1}")))))
 
 (deftest test-entity-refs
-  (let [db (-> (d/empty-db {:father   {:db/valueType   :db.type/ref}
+  (let [db (-> (d/empty-db {:father   {:db/valueType   :db.type/ref
+                                       :db/order 0}
                             :children {:db/valueType   :db.type/ref
-                                       :db/cardinality :db.cardinality/many}})
+                                       :db/cardinality :db.cardinality/many
+                                       :db/order 1}})
                (d/db-with
                  [{:db/id 1, :children [10]}
                   {:db/id 10, :father 1, :children [100 101]}
@@ -81,7 +90,8 @@
     )))
 
 (deftest test-entity-misses
-  (let [db (-> (d/empty-db {:name {:db/unique :db.unique/identity}})
+  (let [db (-> (d/empty-db {:name {:db/unique :db.unique/identity
+                                   :db/order 0}})
              (d/db-with [{:db/id 1, :name "Ivan"}
                          {:db/id 2, :name "Oleg"}]))]
     (is (nil? (d/entity db nil)))

--- a/test/datascript/test/index.cljc
+++ b/test/datascript/test/index.cljc
@@ -8,7 +8,9 @@
 
 (deftest test-datoms
   (let [dvec #(vector (:e %) (:a %) (:v %))
-        db (-> (d/empty-db { :age  { :db/index true } })
+        db (-> (d/empty-db { :age  { :db/index true
+                                     :db/order 0}
+                            :name {:db/order 1}})
                (d/db-with [ [:db/add 1 :name "Petr"]
                             [:db/add 1 :age 44]
                             [:db/add 2 :name "Ivan"]
@@ -17,43 +19,45 @@
                             [:db/add 3 :age 11] ]))]
     (testing "Main indexes, sort order"
       (is (= (map dvec (d/datoms db :aevt))
-             [ [1 :age 44]
-               [2 :age 25]
-               [3 :age 11]
-               [1 :name "Petr"]
-               [2 :name "Ivan"]
-               [3 :name "Sergey"] ]))
+             [ [1 0 44]
+               [2 0 25]
+               [3 0 11]
+               [1 1 "Petr"]
+               [2 1 "Ivan"]
+               [3 1 "Sergey"] ]))
 
       (is (= (map dvec (d/datoms db :eavt))
-             [ [1 :age 44]
-               [1 :name "Petr"]
-               [2 :age 25]
-               [2 :name "Ivan"]
-               [3 :age 11]
-               [3 :name "Sergey"] ]))
+             [ [1 0 44]
+               [1 1 "Petr"]
+               [2 0 25]
+               [2 1 "Ivan"]
+               [3 0 11]
+               [3 1 "Sergey"] ]))
 
       (is (= (map dvec (d/datoms db :avet))
-             [ [3 :age 11]
-               [2 :age 25]
-               [1 :age 44] ]))) ;; name non-indexed, excluded from avet
+             [ [3 0 11]
+               [2 0 25]
+               [1 0 44] ]))) ;; name non-indexed, excluded from avet
 
     (testing "Components filtration"
       (is (= (map dvec (d/datoms db :eavt 1))
-             [ [1 :age 44]
-               [1 :name "Petr"] ]))
+             [ [1 0 44]
+               [1 1 "Petr"] ]))
 
       (is (= (map dvec (d/datoms db :eavt 1 :age))
-             [ [1 :age 44] ]))
+             [ [1 0 44] ]))
 
       (is (= (map dvec (d/datoms db :avet :age))
-             [ [3 :age 11]
-               [2 :age 25]
-               [1 :age 44] ])))))
+             [ [3 0 11]
+               [2 0 25]
+               [1 0 44] ])))))
 
 (deftest test-seek-datoms
   (let [dvec #(vector (:e %) (:a %) (:v %))
-        db (-> (d/empty-db { :name { :db/index true }
-                             :age  { :db/index true } })
+        db (-> (d/empty-db { :name { :db/index true
+                                     :db/order 1}
+                             :age  { :db/index true
+                                     :db/order 0} })
                (d/db-with [[:db/add 1 :name "Petr"]
                            [:db/add 1 :age 44]
                            [:db/add 2 :name "Ivan"]
@@ -63,27 +67,29 @@
 
     (testing "Non-termination"
       (is (= (map dvec (d/seek-datoms db :avet :age 10))
-             [ [3 :age 11]
-               [2 :age 25]
-               [1 :age 44]
-               [2 :name "Ivan"]
-               [1 :name "Petr"]
-               [3 :name "Sergey"] ])))
+             [ [3 0 11]
+               [2 0 25]
+               [1 0 44]
+               [2 1 "Ivan"]
+               [1 1 "Petr"]
+               [3 1 "Sergey"] ])))
 
     (testing "Closest value lookup"
       (is (= (map dvec (d/seek-datoms db :avet :name "P"))
-             [ [1 :name "Petr"]
-               [3 :name "Sergey"] ])))
+             [ [1 1 "Petr"]
+               [3 1 "Sergey"] ])))
 
     (testing "Exact value lookup"
       (is (= (map dvec (d/seek-datoms db :avet :name "Petr"))
-             [ [1 :name "Petr"]
-               [3 :name "Sergey"] ])))))
+             [ [1 1 "Petr"]
+               [3 1 "Sergey"] ])))))
 
 (deftest test-rseek-datoms
   (let [dvec #(vector (:e %) (:a %) (:v %))
-        db (-> (d/empty-db { :name { :db/index true }
-                             :age  { :db/index true } })
+        db (-> (d/empty-db {:age  {:db/index true
+                                   :db/order 0}
+                            :name {:db/index true
+                                   :db/order 1}})
                (d/db-with [[:db/add 1 :name "Petr"]
                            [:db/add 1 :age 44]
                            [:db/add 2 :name "Ivan"]
@@ -93,65 +99,67 @@
 
     (testing "Non-termination"
       (is (= (map dvec (d/rseek-datoms db :avet :name "Petr"))
-             [ [1 :name "Petr"]
-               [2 :name "Ivan"]
-               [1 :age 44]
-               [2 :age 25]
-               [3 :age 11]])))
+             [ [1 1 "Petr"]
+               [2 1 "Ivan"]
+               [1 0 44]
+               [2 0 25]
+               [3 0 11]])))
 
     (testing "Closest value lookup"
       (is (= (map dvec (d/rseek-datoms db :avet :age 26))
-             [ [2 :age 25]
-               [3 :age 11]])))
+             [ [2 0 25]
+               [3 0 11]])))
 
     (testing "Exact value lookup"
       (is (= (map dvec (d/rseek-datoms db :avet :age 25))
-             [ [2 :age 25]
-               [3 :age 11]])))))
+             [ [2 0 25]
+               [3 0 11]])))))
 
 (deftest test-index-range
   (let [dvec #(vector (:e %) (:a %) (:v %))
         db    (d/db-with
-                (d/empty-db { :name { :db/index true}
-                              :age  { :db/index true} })
+                (d/empty-db { :name { :db/index true
+                                     :db/order 1}
+                              :age  { :db/index true
+                                     :db/order 0} })
                 [ { :db/id 1 :name "Ivan"   :age 15 }
                   { :db/id 2 :name "Oleg"   :age 20 }
                   { :db/id 3 :name "Sergey" :age 7 }
                   { :db/id 4 :name "Pavel"  :age 45 }
                   { :db/id 5 :name "Petr"   :age 20 } ])]
     (is (= (map dvec (d/index-range db :name "Pe" "S"))
-           [ [5 :name "Petr"] ]))
+           [ [5 1 "Petr"] ]))
     (is (= (map dvec (d/index-range db :name "O" "Sergey"))
-           [ [2 :name "Oleg"]
-             [4 :name "Pavel"]
-             [5 :name "Petr"]
-             [3 :name "Sergey"] ]))
+           [ [2 1 "Oleg"]
+             [4 1 "Pavel"]
+             [5 1 "Petr"]
+             [3 1 "Sergey"] ]))
 
     (is (= (map dvec (d/index-range db :name nil "P"))
-           [ [1 :name "Ivan"]
-             [2 :name "Oleg"] ]))
+           [ [1 1 "Ivan"]
+             [2 1 "Oleg"] ]))
     (is (= (map dvec (d/index-range db :name "R" nil))
-           [ [3 :name "Sergey"] ]))
+           [ [3 1 "Sergey"] ]))
     (is (= (map dvec (d/index-range db :name nil nil))
-           [ [1 :name "Ivan"]
-             [2 :name "Oleg"]
-             [4 :name "Pavel"]
-             [5 :name "Petr"]
-             [3 :name "Sergey"] ]))
+           [ [1 1 "Ivan"]
+             [2 1 "Oleg"]
+             [4 1 "Pavel"]
+             [5 1 "Petr"]
+             [3 1 "Sergey"] ]))
 
     (is (= (map dvec (d/index-range db :age 15 20))
-           [ [1 :age 15]
-             [2 :age 20]
-             [5 :age 20]]))
+           [ [1 0 15]
+             [2 0 20]
+             [5 0 20]]))
     (is (= (map dvec (d/index-range db :age 7 45))
-           [ [3 :age 7]
-             [1 :age 15]
-             [2 :age 20]
-             [5 :age 20]
-             [4 :age 45] ]))
+           [ [3 0 7]
+             [1 0 15]
+             [2 0 20]
+             [5 0 20]
+             [4 0 45] ]))
     (is (= (map dvec (d/index-range db :age 0 100))
-           [ [3 :age 7]
-             [1 :age 15]
-             [2 :age 20]
-             [5 :age 20]
-             [4 :age 45] ]))))
+           [ [3 0 7]
+             [1 0 15]
+             [2 0 20]
+             [5 0 20]
+             [4 0 45] ]))))

--- a/test/datascript/test/listen.cljc
+++ b/test/datascript/test/listen.cljc
@@ -7,7 +7,8 @@
     [datascript.test.core :as tdc]))
 
 (deftest test-listen!
-  (let [conn    (d/create-conn)
+  (let [conn    (d/create-conn {:name {:db/order 0}
+                                :age {:db/order 1}})
         reports (atom [])]
     (d/transact! conn [[:db/add -1 :name "Alex"]
                        [:db/add -2 :name "Boris"]])
@@ -23,16 +24,16 @@
     (d/transact! conn [[:db/add -1 :name "Geogry"]])
     
     (is (= (:tx-data (first @reports))
-           [(db/datom 3 :name "Dima"   (+ d/tx0 2) true)
-            (db/datom 3 :age 19        (+ d/tx0 2) true)
-            (db/datom 4 :name "Evgeny" (+ d/tx0 2) true)]))
+           [(db/datom 3 0 "Dima"   (+ d/tx0 2) true)
+            (db/datom 3 1 19        (+ d/tx0 2) true)
+            (db/datom 4 0 "Evgeny" (+ d/tx0 2) true)]))
     (is (= (:tx-meta (first @reports))
            {:some-metadata 1}))
     (is (= (:tx-data (second @reports))
-           [(db/datom 5 :name "Fedor"  (+ d/tx0 3) true)
-            (db/datom 1 :name "Alex"   (+ d/tx0 3) false)  ;; update -> retract
-            (db/datom 1 :name "Alex2"  (+ d/tx0 3) true)   ;;         + add
-            (db/datom 4 :name "Evgeny" (+ d/tx0 3) false)]))
+           [(db/datom 5 0 "Fedor"  (+ d/tx0 3) true)
+            (db/datom 1 0 "Alex"   (+ d/tx0 3) false)  ;; update -> retract
+            (db/datom 1 0 "Alex2"  (+ d/tx0 3) true)   ;;         + add
+            (db/datom 4 0 "Evgeny" (+ d/tx0 3) false)]))
     (is (= (:tx-meta (second @reports))
            nil))
     ))

--- a/test/datascript/test/query_find_specs.cljc
+++ b/test/datascript/test/query_find_specs.cljc
@@ -7,7 +7,8 @@
     [datascript.test.core :as tdc]))
 
 (def test-db (d/db-with
-               (d/empty-db)
+               (d/empty-db {:name {:db/order 0}
+                            :age {:db/order 1}})
                [[:db/add 1 :name "Petr"]
                 [:db/add 1 :age 44]
                 [:db/add 2 :name "Ivan"]

--- a/test/datascript/test/query_fns.cljc
+++ b/test/datascript/test/query_fns.cljc
@@ -16,7 +16,11 @@
                   :where [(> 2 1)]] [:a :b :c])
            #{[:a] [:b] [:c]})))
 
-  (let [db (-> (d/empty-db {:parent {:db/valueType :db.type/ref}})
+  (let [db (-> (d/empty-db {:parent {:db/order 0
+                                     :db/valueType :db.type/ref}
+                            :age {:db/order 1}
+                            :name {:db/order 2}
+                            :height {:db/order 3}})
                (d/db-with [ { :db/id 1, :name  "Ivan",  :age   15 }
                             { :db/id 2, :name  "Petr",  :age   22, :height 240, :parent 1}
                             { :db/id 3, :name  "Slava", :age   37, :parent 2}]))]
@@ -41,9 +45,9 @@
       (is (= (d/q '[:find ?e ?a ?v
                     :where [?e :name _]
                            [(get-some $ ?e :height :age) [?a ?v]]] db)
-             #{[1 :age 15]
-               [2 :height 240]
-               [3 :age 37]})))
+             #{[1 1 15]
+               [2 3 240]
+               [3 1 37]})))
 
     (testing "missing?"
       (is (= (q/q '[:find ?e ?age
@@ -207,7 +211,9 @@
                   {:db/id 2 :name "Ivan" :age 20}
                   {:db/id 3 :name "Oleg" :age 10}
                   {:db/id 4 :name "Oleg" :age 20}]
-        db (d/db-with (d/empty-db) entities)]
+        db (d/db-with (d/empty-db {:name {:db/order 0}
+                                   :age {:db/order 1}})
+                      entities)]
     (are [q res] (= (q/q (quote q) db) res)
       ;; plain predicate
       [:find  ?e ?a
@@ -278,7 +284,9 @@
                 :where [_ :pred ?pred]
                        [?e :age ?a]
                        [(?pred ?a)]]
-              (d/db-with (d/empty-db) [[:db/add 1 :age 20]])))))
+              (d/db-with (d/empty-db {:age {:db/order 0}
+                                      :pred {:db/order 1}})
+                         [[:db/add 1 :age 20]])))))
 
 (defn sample-query-fn [] 42)
 

--- a/test/datascript/test/query_not.cljc
+++ b/test/datascript/test/query_not.cljc
@@ -11,7 +11,8 @@
 
 (def test-db
   (delay
-    (d/db-with (d/empty-db)
+    (d/db-with (d/empty-db {:name {:db/order 0}
+                            :age {:db/order 1}})
       [ {:db/id 1 :name "Ivan" :age 10}
         {:db/id 2 :name "Ivan" :age 20}
         {:db/id 3 :name "Oleg" :age 10}
@@ -85,10 +86,11 @@
   
 
 (deftest test-default-source
-  (let [db1 (d/db-with (d/empty-db)
+  (let [db1 (d/db-with (d/empty-db {:name {:db/order 0}
+                                    :age {:db/order 1}})
              [ [:db/add 1 :name "Ivan" ]
                [:db/add 2 :name "Oleg"] ])
-        db2 (d/db-with (d/empty-db)
+        db2 (d/db-with (d/empty-db {:age {:db/order 1}})
              [ [:db/add 1 :age 10 ]
                [:db/add 2 :age 20] ])]
     (are [q res] (= (q/q (concat '[:find ?e :in $ $2 :where] (quote q)) db1 db2)

--- a/test/datascript/test/query_or.cljc
+++ b/test/datascript/test/query_or.cljc
@@ -11,7 +11,8 @@
 
 (def test-db
   (delay
-    (d/db-with (d/empty-db)
+    (d/db-with (d/empty-db {:name {:db/order 0}
+                            :age {:db/order 1}})
       [ {:db/id 1 :name "Ivan" :age 10}
         {:db/id 2 :name "Ivan" :age 20}
         {:db/id 3 :name "Oleg" :age 10}
@@ -72,10 +73,10 @@
       #{1 2 3 4 5 6})))
 
 (deftest test-default-source
-  (let [db1 (d/db-with (d/empty-db)
+  (let [db1 (d/db-with (d/empty-db {:name {:db/order 0}})
              [ [:db/add 1 :name "Ivan" ]
                [:db/add 2 :name "Oleg"] ])
-        db2 (d/db-with (d/empty-db)
+        db2 (d/db-with (d/empty-db {:age {:db/order 1}})
              [ [:db/add 1 :age 10 ]
                [:db/add 2 :age 20] ])]
     (are [q res] (= (q/q (concat '[:find ?e :in $ $2 :where] (quote q)) db1 db2)

--- a/test/datascript/test/query_pull.cljc
+++ b/test/datascript/test/query_pull.cljc
@@ -6,7 +6,7 @@
     [datascript.db :as db]
     [datascript.test.core :as tdc]))
 
-(def test-db (d/db-with (d/empty-db)
+(def test-db (d/db-with (d/empty-db {:name {:db/order 0} :age {:db/order 1}})
              [{:db/id 1 :name "Petr" :age 44}
               {:db/id 2 :name "Ivan" :age 25}
               {:db/id 3 :name "Oleg" :age 11}]))
@@ -58,8 +58,10 @@
            [1 [:age]  {:age 44}]})))
 
 (deftest test-multiple-sources
-  (let [db1 (d/db-with (d/empty-db) [{:db/id 1 :name "Ivan" :age 25}])
-        db2 (d/db-with (d/empty-db) [{:db/id 1 :name "Petr" :age 25}])]
+  (let [schema {:name {:db/order 0}
+                :age {:db/order 1}}
+        db1 (d/db-with (d/empty-db schema) [{:db/id 1 :name "Ivan" :age 25}])
+        db2 (d/db-with (d/empty-db schema) [{:db/id 1 :name "Petr" :age 25}])]
     (is (= (set (d/q '[:find ?e (pull $1 ?e [:name])
                        :in $1 $2
                        :where [$1 ?e :age 25]]
@@ -108,7 +110,9 @@
          {:name "Ivan"})))
 
 (deftest test-aggregates
-  (let [db (d/db-with (d/empty-db {:value {:db/cardinality :db.cardinality/many}})
+  (let [db (d/db-with (d/empty-db {:value {:db/cardinality :db.cardinality/many
+                                           :db/order 0}
+                                   :name {:db/order 1}})
              [{:db/id 1 :name "Petr" :value [10 20 30 40]}
               {:db/id 2 :name "Ivan" :value [14 16]}
               {:db/id 3 :name "Oleg" :value 1}])]
@@ -120,7 +124,9 @@
              [3 {:name "Oleg"} 1 1]}))))
 
 (deftest test-lookup-refs
-  (let [db (d/db-with (d/empty-db {:name { :db/unique :db.unique/identity }})
+  (let [db (d/db-with (d/empty-db {:name { :db/unique :db.unique/identity
+                                           :db/order 0}
+                                   :age {:db/order 1}})
              [{:db/id 1 :name "Petr" :age 44}
               {:db/id 2 :name "Ivan" :age 25}
               {:db/id 3 :name "Oleg" :age 11}])]

--- a/test/datascript/test/query_rules.cljc
+++ b/test/datascript/test/query_rules.cljc
@@ -164,7 +164,7 @@
 
 ;; https://github.com/tonsky/datascript/issues/218
 (deftest test-false-arguments
-  (let [db    (d/db-with (d/empty-db) 
+  (let [db    (d/db-with (d/empty-db {:attr {:db/order 0}})
                 [[:db/add 1 :attr true]
                  [:db/add 2 :attr false]])
         rules '[[(is ?id ?val)

--- a/test/datascript/test/serialization.cljc
+++ b/test/datascript/test/serialization.cljc
@@ -1,110 +1,119 @@
 (ns datascript.test.serialization
   (:require
     [#?(:cljs cljs.reader :clj clojure.edn) :as edn]
-    #?(:cljs [cljs.test    :as t :refer-macros [is are deftest testing]]
-       :clj  [clojure.test :as t :refer        [is are deftest testing]])
+    #?(:cljs [cljs.test :as t :refer-macros [is are deftest testing]]
+       :clj
+    [clojure.test :as t :refer [is are deftest testing]])
     [datascript.core :as d]
     [datascript.db :as db]
     [datascript.test.core :as tdc])
-    #?(:clj
-      (:import [clojure.lang ExceptionInfo])))
+  #?(:clj
+     (:import [clojure.lang ExceptionInfo])))
 
 (def readers
-  { #?@(:cljs ["cljs.reader/read-string"  cljs.reader/read-string]
-        :clj  ["clojure.edn/read-string"  #(clojure.edn/read-string {:readers d/data-readers} %)
-               "clojure.core/read-string" read-string]) })
+  {#?@(:cljs ["cljs.reader/read-string" cljs.reader/read-string]
+       :clj  ["clojure.edn/read-string" #(clojure.edn/read-string {:readers d/data-readers} %)
+              "clojure.core/read-string" read-string])})
+
+(do db/tx0)
 
 (deftest test-pr-read
   (doseq [[r read-fn] readers]
     (testing r
-      (let [d (db/datom 1 :name "Oleg" 17 true)]
-        (is (= (pr-str d) "#datascript/Datom [1 :name \"Oleg\" 17 true]"))
+      (let [d (db/datom 1 0 "Oleg" 15728650 true)]
+        (is (= (pr-str d) "#datascript/Datom [1 0 \"Oleg\" 15728650 true]"))
         (is (= d (read-fn (pr-str d)))))
-      
-      (let [d (db/datom 1 :name 3)]
-        (is (= (pr-str d) "#datascript/Datom [1 :name 3 536870912 true]"))
+
+      (let [d (db/datom 1 0 3)]
+        (is (= (pr-str d) "#datascript/Datom [1 0 3 16777215 true]"))
         (is (= d (read-fn (pr-str d)))))
-      
-      (let [db (-> (d/empty-db {:name {:db/unique :db.unique/identity}})
-                   (d/db-with [ [:db/add 1 :name "Petr"]
-                                [:db/add 1 :age 44] ])
-                   (d/db-with [ [:db/add 2 :name "Ivan"] ]))]
+
+      (let [db (-> (d/empty-db {:name {:db/unique :db.unique/identity
+                                       :db/order 0}
+                                :age {:db/order 1}})
+                   (d/db-with [[:db/add 1 :name "Petr"]
+                               [:db/add 1 :age 44]])
+                   (d/db-with [[:db/add 2 :name "Ivan"]]))]
         (is (= (pr-str db)
                (str "#datascript/DB {"
-                    ":schema {:name {:db/unique :db.unique/identity}}, "
+                    ":schema {:name {:db/unique :db.unique/identity, :db/order 0},"
+                    " :age {:db/order 1}}, "
                     ":datoms ["
-                      "[1 :age 44 536870913] "
-                      "[1 :name \"Petr\" 536870913] "
-                      "[2 :name \"Ivan\" 536870914]"
+                    "[1 0 \"Petr\" 16777214] "
+                    "[1 1 44 16777214] "
+                    "[2 0 \"Ivan\" 16777213]"
                     "]}")))
         (is (= db (read-fn (pr-str db))))))))
 
+;(- db/tx0 db/tx-mask)
+
 #?(:clj
-  (deftest test-reader-literals
-    (is (= #datascript/Datom [1 :name "Oleg"]
-                    (db/datom 1 :name "Oleg")))
-    (is (= #datascript/Datom [1 :name "Oleg" 100 false]
-                    (db/datom 1 :name "Oleg" 100 false)))
-    ;; not supported because IRecord print method is hard-coded into Compiler
-    #_(is (= #datascript/DB {:schema {:name {:db/unique :db.unique/identity}}
-                           :datoms [[1 :name "Oleg" 100] [1 :age 14 100] [2 :name "Petr" 101]]}
-           (d/init-db 
-             [ (db/datom 1 :name "Oleg" 100)
-               (db/datom 1 :age 14 100)
-               (db/datom 2 :name "Petr" 101) ]
-             {:name {:db/unique :db.unique/identity}})))))
+   (deftest test-reader-literals
+     (is (= #datascript/Datom [1 0 "Oleg"]
+            (db/datom 1 0 "Oleg")))
+     (is (= #datascript/Datom [1 0 "Oleg" 16777200 false]
+            (db/datom 1 0 "Oleg" 16777200 false)))
+     ;; not supported because IRecord print method is hard-coded into Compiler
+     #_(is (= #datascript/DB {:schema {:name {:db/unique :db.unique/identity :db/order 0}
+                                       :age {:db/order 1}}
+                              :datoms [[1 0 "Oleg" 100] [1 1 14 100] [2 0 "Petr" 101]]}
+              (d/init-db
+                [(db/datom 1 0 "Oleg" 100)
+                 (db/datom 1 1 14 100)
+                 (db/datom 2 0 "Petr" 101)]
+                {:name {:db/unique :db.unique/identity :db/order 0}
+                 :age {:db/order 1}})))))
 
 
 (def data
-  [[1 :name    "Petr"]
-   [1 :aka     "Devil"]
-   [1 :aka     "Tupen"]
-   [1 :age     15]
-   [1 :follows 2]
-   [1 :email   "petr@gmail.com"]
-   [1 :avatar  10]
-   [10 :url    "http://"]
-   [1 :attach  { :some-key :some-value }]
-   [2 :name    "Oleg"]
-   [2 :age     30]
-   [2 :email   "oleg@gmail.com"]
-   [2 :attach  [ :just :values ]]
-   [3 :name    "Ivan"]
-   [3 :age     15]
-   [3 :follows 2]
-   [3 :attach  { :another :map }]
-   [3 :avatar  30]
-   [4 :name    "Nick" d/tx0]
+  [[1 0 "Petr"]
+   [1 1 "Devil"]
+   [1 1 "Tupen"]
+   [1 2 15]
+   [1 3 2]
+   [1 4 "petr@gmail.com"]
+   [1 5 10]
+   [10 6 "http://"]
+   [1 7 {:some-key :some-value}]
+   [2 0 "Oleg"]
+   [2 2 30]
+   [2 4 "oleg@gmail.com"]
+   [2 7 [:just :values]]
+   [3 0 "Ivan"]
+   [3 2 15]
+   [3 3 2]
+   [3 7 {:another :map}]
+   [3 5 30]
+   [4 0 "Nick" d/tx0]
    ;; check that facts about transactions doesn’t set off max-eid
-   [d/tx0      :txInstant 0xdeadbeef]
-   [30 :url    "https://" ]])
+   [d/tx0 8 0xdeadbeef]
+   [30 6 "https://"]])
 
 
-(def schema 
-  { :name    { } ;; nothing special about name
-    :aka     { :db/cardinality :db.cardinality/many }
-    :age     { :db/index true }
-    :follows { :db/valueType :db.type/ref }
-    :email   { :db/unique :db.unique/identity }
-    :avatar  { :db/valueType :db.type/ref, :db/isComponent true }
-    :url     { } ;; just a component prop
-    :attach  { } ;; should skip index
-})
-
+(def schema
+  {:name    {:db/order 0}                                   ;; nothing special about name
+   :aka     {:db/cardinality :db.cardinality/many :db/order 1}
+   :age     {:db/index true :db/order 2}
+   :follows {:db/valueType :db.type/ref :db/order 3}
+   :email   {:db/unique :db.unique/identity :db/order 4}
+   :avatar  {:db/valueType :db.type/ref, :db/isComponent true :db/order 5}
+   :url     {:db/order 6}                                   ;; just a component prop
+   :attach  {:db/order 7}                                   ;; should skip index
+   :txInstant {:db/order 8}})
 
 (deftest test-init-db
-  (let [db-init     (-> (map #(apply d/datom %) data)
-                        (d/init-db schema))
+  (let [db-init (-> (map #(apply d/datom %) data)
+                    (d/init-db schema))
         db-transact (->> (map (fn [[e a v]] [:db/add e a v]) data)
                          (d/db-with (d/empty-db schema)))]
     (testing "db-init produces the same result as regular transactions"
       (is (= db-init db-transact)))
 
     (testing "db-init produces the same max-eid as regular transactions"
-      (let [assertions [ [:db/add -1 :name "Lex"] ]]
+      (let [assertions [[:db/add -1 :name "Lex"]]]
         (is (= (d/db-with db-init assertions)
                (d/db-with db-transact assertions)))))
-    
+
     (testing "Roundtrip"
       (doseq [[r read-fn] readers]
         (testing r

--- a/test/datascript/test/validation.cljc
+++ b/test/datascript/test/validation.cljc
@@ -9,11 +9,13 @@
    (def Throwable js/Error))
 
 (deftest test-with-validation
-  (let [db (d/empty-db {:profile { :db/valueType :db.type/ref }})]
+  (let [db (d/empty-db {:profile { :db/valueType :db.type/ref
+                                   :db/order 0}
+                        :name {:db/order 1}})]
     (are [tx] (thrown-with-msg? Throwable #"Expected number, string or lookup ref for :db/id" (d/db-with db tx))
       [{:db/id #"" :name "Ivan"}])
     
-    (are [tx] (thrown-with-msg? Throwable #"Bad entity attribute" (d/db-with db tx))
+    #_(are [tx] (thrown-with-msg? Throwable #"Bad entity attribute" (d/db-with db tx))
       [[:db/add -1 nil "Ivan"]]
       [[:db/add -1 17 "Ivan"]]
       [{:db/id -1 17 "Ivan"}])
@@ -34,11 +36,13 @@
     (is (thrown-with-msg? Throwable #"Bad transaction data" (d/db-with db {:profile "aaa"})))))
 
 (deftest test-unique
-  (let [db (d/db-with (d/empty-db {:name { :db/unique :db.unique/value }})
+  (let [db (d/db-with (d/empty-db {:name { :db/unique :db.unique/value
+                                          :db/order 0}
+                                   :nick {:db/order 1}})
                       [[:db/add 1 :name "Ivan"]
                        [:db/add 2 :name "Petr"]])]
     (are [tx] (thrown-with-msg? Throwable #"unique constraint" (d/db-with db tx))
       [[:db/add 3 :name "Ivan"]]
-      [{:db/add 3 :name "Petr"}])
+      [{:db/id 3 :name "Petr"}])
     (d/db-with db [[:db/add 3 :name "Igor"]])
     (d/db-with db [[:db/add 3 :nick "Ivan"]])))


### PR DESCRIPTION
As I would like to use Datascript for large datasets, I am trying to optimise the memory usage.
This patch should reduce memory usage by at least 50%.
```clj
[tuned-datascript "0.16.5-SNAPSHOT"]
```

There are some changes to the API:
- Attributes are stored as Integers (d/datom 0 :attr :val) is not allowed anymore
- Queries return attributes as Integers, not Keywords
- You need to define the Attribute order in the schema -> {:attr {:db/order 0}}
- Transaction Id's are created from 2^24 -1 downwards
- New range for Entity ID's is from 0 to 2^24
- New range for valid Transaction ID's is from 2^24 to (2^24) - 2^20

Internally the new Datom type is implemented as a pointer to :v and a number, which stores Eid and Aid in the lower 32 bits. The remaining 21 Bits in the double number are used for the added flag and the transaction ID.

Needs some work on the JS wrapper and I could not figure out how to benchmark Datascript.