### PR TITLE
Add `bench/src` making `datascript.query-v3` available to Clojure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ web/target-cljs
 .idea
 *.iml
 .vscode
+.cpcache/

--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,8 @@
+{:paths ["src" "bench/src"]
+
+ :deps
+ {org.clojure/clojure   {:mvn/version "1.9.0"}}
+
+ :aliases
+ {:dev
+  {:extra-paths ["dev" "test"]}}}

--- a/project.clj
+++ b/project.clj
@@ -101,7 +101,8 @@
            :global-vars  { *print-namespace-maps* false }}
     :dev { :source-paths ["bench/src" "test" "dev"]
            :dependencies [[org.clojure/tools.nrepl "0.2.12"]] }
-    :deploy { :aot [#"datascript\.(?!query-v3).*"]
+    :deploy { :source-paths ["src" "bench/src"]
+              :aot [#"datascript\.(?!query-v3).*"]
               :jvm-opts ["-Dclojure.compiler.direct-linking=true"] }
   }
   


### PR DESCRIPTION
`datascript.query-v3` depends on `datascript.perf` as of now which is defined as part of `bench/src`.

`bench/src` is added to the ClojureScript build but not to the Clojure build making query-v3 accidentally unavailable to Clojure developers.

This patch fixes that.