### PR TITLE
Fix typo in listen! docs

### DIFF
--- a/src/datascript/core.cljc
+++ b/src/datascript/core.cljc
@@ -555,7 +555,7 @@
   "Listen for changes on the given connection. Whenever a transaction is applied to the database via [[transact!]], the callback is called
    with the transaction report. `key` is any opaque unique value.
    
-   Idempotent. Calling [[listen!]] with the same twice will override old callback with the new value.
+   Idempotent. Calling [[listen!]] with the same key twice will override old callback with the new value.
    
    Returns the key under which this listener is registered. See also [[unlisten!]]."
   ([conn callback] (listen! conn (rand) callback))


### PR DESCRIPTION
Think I found a typo. Is this what you meant?

Also, thanks a lot for datascript. Having a high-quality database that can be deployed alongside the application is super-sweet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tonsky/datascript/299)
<!-- Reviewable:end -->
