### PR TITLE
Update cljs build settings

### DIFF
--- a/dev/user.clj
+++ b/dev/user.clj
@@ -4,25 +4,13 @@
     [clojure.string :as str]
     clojure.tools.namespace.repl
     cljs.repl
+    cljs.closure
     cljs.build.api
     cljs.repl.node
     cljs.repl.browser))
 
-(defrecord Dirs [dirs]
-  cljs.closure/Inputs
-  (-paths [_]
-    (mapv clojure.java.io/file dirs))
-  
-  cljs.closure/Compilable
-  (-compile [_ opts]
-    (let [out-dir (cljs.util/output-directory opts)]
-      (vec
-        (for [src-dir dirs
-              root    (cljs.compiler/compile-root src-dir out-dir opts)]
-          (cljs.closure/compiled-file root))))))
-
 (defn repl [main env & dirs]
-  (cljs.build.api/build (Dirs. (concat ["src" "test"] dirs))
+  (cljs.build.api/build (cljs.closure/compilable-input-paths (concat ["src" "test"] dirs))
     {:main       main
      :output-to  "target/datascript.js"
      :output-dir "target/none"
@@ -30,7 +18,7 @@
      :verbose    true})
 
   (cljs.repl/repl env
-    :watch      (Dirs. (concat ["src" "test"] dirs))
+    :watch      (cljs.closure/compilable-input-paths (concat ["src" "test"] dirs))
     :output-dir "target/none"))
 
 (defn browser-repl []


### PR DESCRIPTION
The cljs.closure/Compilable protocol has two methods and right now
running `(node-repl)` from the user ns throws an error about the
missing method `find-sources`