### PR TITLE
Remove call to `persistent!` in cljs lru print function

### DIFF
--- a/src/datascript/lru.cljc
+++ b/src/datascript/lru.cljc
@@ -12,7 +12,7 @@
       (-lookup [_ k nf] (-lookup key-value k nf))
       IPrintWithWriter
       (-pr-writer [_ writer opts]
-                  (-pr-writer (persistent! key-value) writer opts)))
+                  (-pr-writer key-value writer opts)))
    :clj
     (deftype LRU [^clojure.lang.Associative key-value gen-key key-gen gen limit]
       clojure.lang.ILookup


### PR DESCRIPTION
no longer pased on transients. And even if it were calling persistent
on a transient in a side-effecting operation that changes the
transient.

This error would manifest itself just by calling the lru function:

```cljs
(require '[datascript.lru :as lru])
(lru/lru 3)
**error no protocol method -persistent!

```