### PR TITLE
Add `re-pattern` to builtins

### DIFF
--- a/src/datascript/query.cljc
+++ b/src/datascript/query.cljc
@@ -202,10 +202,10 @@
   'vector vector, 'list list, 'set set, 'hash-map hash-map, 'array-map array-map,
   'count count, 'range range, 'not-empty not-empty, 'empty? empty, 'contains? contains?,
   'str str, 'pr-str pr-str, 'print-str print-str, 'println-str println-str, 'prn-str prn-str, 'subs subs,
-  're-find re-find, 're-matches re-matches, 're-seq re-seq,
+  're-find re-find, 're-matches re-matches, 're-seq re-seq, 're-pattern re-pattern,
   '-differ? -differ?, 'get-else -get-else, 'get-some -get-some, 'missing? -missing?, 'ground identity})
- 
-(def built-in-aggregates 
+
+(def built-in-aggregates
  (letfn [(sum [coll] (reduce + 0 coll))
          (avg [coll] (/ (sum coll) (count coll)))
          (median

--- a/test/datascript/test/query.cljc
+++ b/test/datascript/test/query.cljc
@@ -210,5 +210,14 @@
          #{[:a 2] [:a 4] [:a 6]
            [:b 2]})))
 
+(deftest test-built-in-regex
+  (is (= (d/q '[:find  ?name
+                :in    [?name ...] ?key
+                :where [(re-pattern ?key) ?pattern]
+                       [(re-find ?pattern ?name)]]
+              #{"abc" "abcX" "aXb"}
+              "X")
+         #{["abcX"] ["aXb"]})))
+
 #_(require 'datascript.test.query :reload)
 #_(clojure.test/test-ns 'datascript.test.query)


### PR DESCRIPTION
Clojure can resolve functions from clojure/string so that you can
check for substrings

`[(clojure.string/includes? ?term "X")]`

Clojurescript lacks this runtime resolution so there is no way to
check for string containment. There are some helpful regex functions
but this requires the regex pattern to be constructed outside of the
query. This change allows to create the pattern in the query as
demonstrated in the test:

``` clojure
(d/q '[:find  ?name
       :in    [?name ...] ?key
       :where [(re-pattern ?key) ?pattern]
              [(re-find ?pattern ?name)]]
     #{"abc" "abcX" "aXb"}
     "X")
```