### PR TITLE
Fixed core.cljc NS declaration to require cljs.reader

### DIFF
--- a/src/datascript/core.cljc
+++ b/src/datascript/core.cljc
@@ -4,7 +4,8 @@
     [datascript.db :as db #?@(:cljs [:refer [FilteredDB]])]
     [datascript.pull-api :as dp]
     [datascript.query :as dq]
-    [datascript.impl.entity :as de])
+    [datascript.impl.entity :as de]
+    #?(:cljs [cljs.reader :as cljs-reader]))
   #?(:clj
     (:import
       [datascript.db FilteredDB]
@@ -583,7 +584,7 @@
                 'datascript/DB    db/db-from-reader})
 
 #?(:cljs
-   (doseq [[tag cb] data-readers] (cljs.reader/register-tag-parser! tag cb)))
+   (doseq [[tag cb] data-readers] (cljs-reader/register-tag-parser! tag cb)))
 
 
 ;; Datomic compatibility layer


### PR DESCRIPTION
Eliminates warning from some build-tooling on use of undeclared var

Specifically, I was getting this warning on every build/reload my shadow-cljs browser app during development.

```clj
------ WARNING #3 - :undeclared-var --------------------------------------------
 Resource: datascript/core.cljc:586:36
 Use of undeclared Var cljs.reader/register-tag-parser!
--------------------------------------------------------------------------------
```

Please edit as desired & thanks for the library!