### PR TITLE
Implement nav/datafy for pull

### DIFF
--- a/src/datascript/datafy.cljc
+++ b/src/datascript/datafy.cljc
@@ -1,0 +1,74 @@
+(ns datascript.datafy
+  (:require [clojure.core.protocols :as cp]
+            [datascript.pull-api :as dp]
+            [clojure.string :as str]))
+
+(declare datafy-entity)
+(declare datafy-entity-seq)
+
+(defn- attr<->rattr [attr]
+  (keyword (namespace attr)
+           (if (str/starts-with? (name attr) "_")
+             (subs (name attr) 1)
+             (str "_" (name attr)))))
+
+(defn- pull-pattern [ref-rattrs]
+  (into ["*"] ref-rattrs))
+
+
+(defn- navize-entity [db-val entity]
+  (let [ref-attrs (:db.type/ref (:rschema db-val))
+        ref-rattrs (set (map attr<->rattr ref-attrs))
+        many-attrs (:db.cardinality/many (:rschema db-val))
+        pull-pattern (into ["*"] ref-rattrs)]
+    (with-meta entity
+               {`cp/nav (fn [coll k v]
+                          (cond
+                            (or (and (many-attrs k) (ref-attrs k))
+                                (ref-rattrs k))
+                            (datafy-entity-seq db-val
+                                               (dp/pull-many db-val pull-pattern (mapv :db/id v)))
+                            (ref-attrs k)
+                            (datafy-entity db-val (dp/pull db-val pull-pattern (:db/id v)))
+                            :else v))})))
+
+(defn- navize-entity-seq [db-val entities]
+  (with-meta entities
+             {`cp/nav (fn [coll k v]
+                        (datafy-entity db-val v))}))
+
+(defn- datafy-entity [db-val entity]
+  (with-meta entity
+             {`cp/datafy (fn [entity]
+                           (navize-entity db-val entity))}))
+
+(defn- datafy-entity-seq [db-val entities]
+  (with-meta entities
+             {`cp/datafy (fn [entities] (navize-entity-seq db-val entities))}))
+
+(defn pull
+  "Same as `datascript.core/pull` but the returned map implements `datafy/nav` (See [https://clojure.github.io/clojure/clojure.datafy-api.html](https://clojure.github.io/clojure/clojure.datafy-api.html).
+
+  This can be used to navigate through the database following ref fields.
+
+  Usage:
+  ```
+  (pull db [:ref, :name] 1)
+  ; => {:db/id 1,
+  ;     :name \"Child\",
+  ;     :ref {:db/id 2}}
+  (nav (datafy (pull db [:ref, :name] 1))
+       :ref
+       {:db/id 2})
+  ; => {:db/id 2,
+  ;     :name \"Parent\",
+  ;     :_ref {:db/id 1}}
+  ```
+  "
+  [db selector eid]
+  (datafy-entity db (dp/pull db selector eid)))
+
+(defn pull-many
+  "Same as [[pull]] but accepts sequence of ids and returns sequence of maps that implements `datafy/nav`."
+  [db selector eids]
+  (datafy-entity-seq db (dp/pull-many db selector eids)))

--- a/src/datascript/datafy.cljc
+++ b/src/datascript/datafy.cljc
@@ -1,74 +1,42 @@
 (ns datascript.datafy
   (:require [clojure.core.protocols :as cp]
             [datascript.pull-api :as dp]
-            [clojure.string :as str]))
+            [datascript.db :as db]
+            [datascript.impl.entity :as e]))
 
-(declare datafy-entity)
 (declare datafy-entity-seq)
-
-(defn- attr<->rattr [attr]
-  (keyword (namespace attr)
-           (if (str/starts-with? (name attr) "_")
-             (subs (name attr) 1)
-             (str "_" (name attr)))))
 
 (defn- pull-pattern [ref-rattrs]
   (into ["*"] ref-rattrs))
 
-
-(defn- navize-entity [db-val entity]
+(defn- navize-pulled-entity [db-val pulled-entity]
   (let [ref-attrs (:db.type/ref (:rschema db-val))
-        ref-rattrs (set (map attr<->rattr ref-attrs))
-        many-attrs (:db.cardinality/many (:rschema db-val))
-        pull-pattern (into ["*"] ref-rattrs)]
-    (with-meta entity
+        ref-rattrs (set (map db/reverse-ref ref-attrs))
+        many-attrs (:db.cardinality/many (:rschema db-val))]
+    (with-meta pulled-entity
                {`cp/nav (fn [coll k v]
                           (cond
                             (or (and (many-attrs k) (ref-attrs k))
                                 (ref-rattrs k))
-                            (datafy-entity-seq db-val
-                                               (dp/pull-many db-val pull-pattern (mapv :db/id v)))
+                            (datafy-entity-seq db-val v)
                             (ref-attrs k)
-                            (datafy-entity db-val (dp/pull db-val pull-pattern (:db/id v)))
+                            (e/entity db-val (:db/id v))
                             :else v))})))
 
-(defn- navize-entity-seq [db-val entities]
+(defn- navize-pulled-entity-seq [db-val entities]
   (with-meta entities
              {`cp/nav (fn [coll k v]
-                        (datafy-entity db-val v))}))
-
-(defn- datafy-entity [db-val entity]
-  (with-meta entity
-             {`cp/datafy (fn [entity]
-                           (navize-entity db-val entity))}))
+                        (e/entity db-val (:db/id v)))}))
 
 (defn- datafy-entity-seq [db-val entities]
   (with-meta entities
-             {`cp/datafy (fn [entities] (navize-entity-seq db-val entities))}))
+             {`cp/datafy (fn [entities] (navize-pulled-entity-seq db-val entities))}))
 
-(defn pull
-  "Same as `datascript.core/pull` but the returned map implements `datafy/nav` (See [https://clojure.github.io/clojure/clojure.datafy-api.html](https://clojure.github.io/clojure/clojure.datafy-api.html).
-
-  This can be used to navigate through the database following ref fields.
-
-  Usage:
-  ```
-  (pull db [:ref, :name] 1)
-  ; => {:db/id 1,
-  ;     :name \"Child\",
-  ;     :ref {:db/id 2}}
-  (nav (datafy (pull db [:ref, :name] 1))
-       :ref
-       {:db/id 2})
-  ; => {:db/id 2,
-  ;     :name \"Parent\",
-  ;     :_ref {:db/id 1}}
-  ```
-  "
-  [db selector eid]
-  (datafy-entity db (dp/pull db selector eid)))
-
-(defn pull-many
-  "Same as [[pull]] but accepts sequence of ids and returns sequence of maps that implements `datafy/nav`."
-  [db selector eids]
-  (datafy-entity-seq db (dp/pull-many db selector eids)))
+(extend-protocol cp/Datafiable
+  datascript.impl.entity.Entity
+  (datafy [this]
+    (let [db (.-db this)
+          ref-attrs (:db.type/ref (:rschema db))
+          ref-rattrs (set (map db/reverse-ref ref-attrs))
+          pull-pattern (into ["*"] ref-rattrs)]
+      (navize-pulled-entity db (dp/pull db pull-pattern (:db/id this))))))

--- a/src/datascript/datafy.cljc
+++ b/src/datascript/datafy.cljc
@@ -6,9 +6,6 @@
 
 (declare datafy-entity-seq)
 
-(defn- pull-pattern [ref-rattrs]
-  (into ["*"] ref-rattrs))
-
 (defn- navize-pulled-entity [db-val pulled-entity]
   (let [ref-attrs (:db.type/ref (:rschema db-val))
         ref-rattrs (set (map db/reverse-ref ref-attrs))

--- a/test/datascript/test.cljc
+++ b/test/datascript/test.cljc
@@ -36,7 +36,8 @@
     datascript.test.transact
     datascript.test.validation
     datascript.test.upsert
-    datascript.test.issues))
+    datascript.test.issues
+    datascript.test.datafy))
 
 (defn ^:export test-clj []
   (datascript.test.core/wrap-res #(t/run-all-tests #"datascript\..*")))

--- a/test/datascript/test/datafy.cljc
+++ b/test/datascript/test/datafy.cljc
@@ -1,0 +1,40 @@
+(ns datascript.test.datafy
+  (:require
+    #?(:cljs [cljs.test    :as t :refer-macros [is are deftest testing]]
+       :clj  [clojure.test :as t :refer        [is are deftest testing]])
+    [datascript.datafy :as datafy]
+    [datascript.core :as d]
+    [clojure.core.protocols :as cp]))
+
+(defn- test-db []
+  (let [schema {:ref {:db/valueType :db.type/ref}
+                :namespace/ref {:db/valueType :db.type/ref}
+                :many/ref {:db/valueType :db.type/ref
+                           :db/cardinality :db.cardinality/many}}
+        db (-> (d/empty-db schema)
+               (d/db-with [{:db/id 1 :name "Parent1"}
+                           {:db/id 2 :name "Child1" :ref 1 :namespace/ref 1}
+                           {:db/id 3 :name "GrandChild1" :ref 2 :namespace/ref 2}
+                           {:db/id 4 :name "Master" :many/ref [1 2 3]}]))]
+    db))
+
+(defn- nav [coll k]
+  (cp/nav coll k (coll k)))
+
+(defn d+n
+  "Helper function to datafy/navigate for a path"
+  [coll [k & ks]]
+  (if (nil? k)
+    coll
+    (d+n (nav (cp/datafy coll) k)
+         ks)))
+
+(deftest test-navigation
+  (let [db (test-db)
+        entity (datafy/pull db [:ref :namespace/ref :many/_ref] 3)]
+    (is (= 2 (:db/id (d+n entity [:ref]))))
+    (is (= 2 (:db/id (d+n entity [:namespace/ref]))))
+    (is (= 1 (:db/id (d+n entity [:ref :namespace/ref]))))
+    (is (= 3 (:db/id (d+n entity [:namespace/ref :ref :_ref 0 :namespace/_ref 0]))))
+    (is (= #{1 2 3} (set (map :db/id (d+n entity [:many/_ref 0 :many/ref])))))))
+

--- a/test/datascript/test/datafy.cljc
+++ b/test/datascript/test/datafy.cljc
@@ -1,10 +1,11 @@
 (ns datascript.test.datafy
   (:require
-    #?(:cljs [cljs.test    :as t :refer-macros [is are deftest testing]]
-       :clj  [clojure.test :as t :refer        [is are deftest testing]])
+    #?(:cljs [cljs.test :as t :refer-macros [is are deftest testing]]
+       :clj  [clojure.test :as t :refer [is are deftest testing]])
     [datascript.datafy :as datafy]
     [datascript.core :as d]
-    [clojure.core.protocols :as cp]))
+    [clojure.core.protocols :as cp]
+    [datascript.impl.entity :as e]))
 
 (defn- test-db []
   (let [schema {:ref {:db/valueType :db.type/ref}
@@ -31,7 +32,7 @@
 
 (deftest test-navigation
   (let [db (test-db)
-        entity (datafy/pull db [:ref :namespace/ref :many/_ref] 3)]
+        entity (e/entity db 3)]
     (is (= 2 (:db/id (d+n entity [:ref]))))
     (is (= 2 (:db/id (d+n entity [:namespace/ref]))))
     (is (= 1 (:db/id (d+n entity [:ref :namespace/ref]))))


### PR DESCRIPTION
The PR contains a version of pull/pull-many that decorates the returning maps with implementations of datafy/nav protocol.

When navigating along ref or _ref fields, it pulls the referenced entities from the db. 
Currently, when navigating, it always pulls all fields (including the reverse refs) to ensure you can navigate back and forth.

I'm not an expert in implementing datafy/nav so feedback is very welcome.

They could replace pull/pull-many of the core. As there should be no difference if you don't call datafy on the result.

For now I have not looked into ways to make the result of queries navigatable.
This touches #313 .