### PR TITLE
Issue 339: Support: db/retract without value

### DIFF
--- a/src/datascript/core.cljc
+++ b/src/datascript/core.cljc
@@ -463,6 +463,9 @@
   
       ; retract single entity attribute
       (transact! conn [[:db.fn/retractAttribute 1 :name]])
+  
+      ; ... or equivalently (since Datomic changed its API to support this):
+      (transact! conn [[:db/retract 1 :name]])
       
       ; retract all entity attributes (effectively deletes entity)
       (transact! conn [[:db.fn/retractEntity 1]])

--- a/src/datascript/db.cljc
+++ b/src/datascript/db.cljc
@@ -1231,7 +1231,8 @@
             (= op :db/add)
             (recur (transact-add report entity) entities)
 
-            (= op :db/retract)
+            (and (= op :db/retract)
+                 v)
             (if-some [e (entid db e)]
               (let [v (if (ref? db a) (entid-strict db v) v)]
                 (validate-attr a entity)
@@ -1241,7 +1242,9 @@
                   (recur report entities)))
               (recur report entities))
 
-            (= op :db.fn/retractAttribute)
+            (or (= op :db.fn/retractAttribute)
+                (and (= op :db/retract)
+                     (nil? v)))
             (if-some [e (entid db e)]
               (let [_      (validate-attr a entity)
                     datoms (vec (-search db [e a]))]

--- a/test/datascript/test/transact.cljc
+++ b/test/datascript/test/transact.cljc
@@ -111,6 +111,25 @@
                     :where [2 ?a ?v]] db)
              #{[:name "Petr"] [:age 37]})))))
 
+(deftest test-retract-without-value-339
+  (let [db (-> (d/empty-db {:aka    { :db/cardinality :db.cardinality/many }
+                            :friend { :db/valueType :db.type/ref }})
+               (d/db-with [ { :db/id 1, :name  "Ivan", :age 15, :aka ["X" "Y" "Z"], :friend 2 }
+                           { :db/id 2, :name  "Petr", :age 37 } ]))]
+    (testing "Retract :name without providing v"
+      (let [db (d/db-with db [[:db/retract 1 :name]])]
+        (is (= (d/q '[:find ?a ?v
+                      :where [1 ?a ?v]]
+                    db)
+               #{[:friend 2] [:age 15] [:aka "Z"] [:aka "Y"] [:aka "X"]}))))
+    (testing "Retract :aka (cardinality many) without providing v"
+      (let [db (d/db-with db [[:db/retract 1 :aka]])]
+        (is (= (d/q '[:find ?a ?v
+                      :where [1 ?a ?v]]
+                    db)
+               #{[:friend 2] [:age 15] [:name "Ivan"]}))))))
+
+  
 (deftest test-retract-fns-not-found
   (let [db  (-> (d/empty-db { :name { :db/unique :db.unique/identity } })
                 (d/db-with  [[:db/add 1 :name "Ivan"]]))


### PR DESCRIPTION
- :db/retract with null value is treated as :db.fn/retractAttribute
- Docstring for 'transact!' is modified to reflect the change