### PR TITLE
Fix `empty?` builtin

### DIFF
--- a/src/datascript/query.cljc
+++ b/src/datascript/query.cljc
@@ -200,7 +200,7 @@
   'complement complement, 'identical? identical?,
   'identity identity, 'meta meta, 'name name, 'namespace namespace, 'type type,
   'vector vector, 'list list, 'set set, 'hash-map hash-map, 'array-map array-map,
-  'count count, 'range range, 'not-empty not-empty, 'empty? empty, 'contains? contains?,
+  'count count, 'range range, 'not-empty not-empty, 'empty? empty?, 'contains? contains?,
   'str str, 'pr-str pr-str, 'print-str print-str, 'println-str println-str, 'prn-str prn-str, 'subs subs,
   're-find re-find, 're-matches re-matches, 're-seq re-seq, 're-pattern re-pattern,
   '-differ? -differ?, 'get-else -get-else, 'get-some -get-some, 'missing? -missing?, 'ground identity,


### PR DESCRIPTION
Fixes following issue:

```clojure
(let [db (d/db-with (d/empty-db) [{:things #{"x" "y" "z"}}
                                  {:things #{}}])]
  (d/q '[:find (count ?e) .
         :where
         [?e :things ?t]
         [(empty? ?t)]]
    db))
    
 ; Expected: 1
 ; Actual: 2
```

I don't think there's any value in adding a test case just for this?

Cheers.