### PR TITLE
fix: ensure transitive property for hash value comparisons

### DIFF
--- a/src/datascript/db.cljc
+++ b/src/datascript/db.cljc
@@ -338,8 +338,8 @@
     #?@(:clj  [(instance? Number x)       (clojure.lang.Numbers/compare x y)])
     #?@(:clj  [(instance? Comparable x)   (.compareTo ^Comparable x y)]
         :cljs [(satisfies? IComparable x) (-compare x y)])
-    #?@(:cljs [(and (or (string? x) (array? x) (true? x) (false? x))
-                 (identical? (type x) (type y))) (garray/defaultCompare x y)])
+    #?@(:cljs [(not (identical? (type x) (type y))) (garray/defaultCompare (type x) (type y))])
+    #?@(:cljs [(or (string? x) (array? x) (true? x) (false? x)) (garray/defaultCompare x y)])
     :else (- (hash x) (hash y))))
 
 (defn value-cmp [x y]

--- a/src/datascript/db.cljc
+++ b/src/datascript/db.cljc
@@ -337,7 +337,7 @@
      :cljs (identical? (type x) (type y))))
 
 (defn class-compare [x y]
-  #?(:clj  (compare (str (class x)) (str (class y)))
+  #?(:clj  (compare (.getName (class x)) (.getName (class y)))
      :cljs (garray/defaultCompare (type x) (type y))))
 
 (defn value-compare [x y]

--- a/src/datascript/db.cljc
+++ b/src/datascript/db.cljc
@@ -332,15 +332,28 @@
     (if (nil? y) 0
       (compare x y))))
 
+(defn class-identical? [x y]
+  #?(:clj  (identical? (class x) (class y))
+     :cljs (identical? (type x) (type y))))
+
+(defn class-compare [x y]
+  #?(:clj  (compare (str (class x)) (str (class y)))
+     :cljs (garray/defaultCompare (type x) (type y))))
+
 (defn value-compare [x y]
-  (cond
-    (= x y) 0
-    #?@(:clj  [(instance? Number x)       (clojure.lang.Numbers/compare x y)])
-    #?@(:clj  [(instance? Comparable x)   (.compareTo ^Comparable x y)]
-        :cljs [(satisfies? IComparable x) (-compare x y)])
-    #?@(:cljs [(not (identical? (type x) (type y))) (garray/defaultCompare (type x) (type y))])
-    #?@(:cljs [(or (string? x) (array? x) (true? x) (false? x)) (garray/defaultCompare x y)])
-    :else (- (hash x) (hash y))))
+  (try 
+    (cond
+      (= x y) 0
+      #?@(:clj  [(instance? Number x)       (clojure.lang.Numbers/compare x y)])
+      #?@(:clj  [(instance? Comparable x)   (.compareTo ^Comparable x y)]
+          :cljs [(satisfies? IComparable x) (-compare x y)])
+      (not (class-identical? x y)) (class-compare x y)
+      #?@(:cljs [(or (string? x) (array? x) (true? x) (false? x)) (garray/defaultCompare x y)])
+      :else (- (hash x) (hash y)))
+    (catch #?(:clj ClassCastException :cljs js/Error) e
+      (if (not (class-identical? x y))
+        (class-compare x y)
+        (throw e)))))
 
 (defn value-cmp [x y]
   (cond 

--- a/test/datascript/test/transact.cljc
+++ b/test/datascript/test/transact.cljc
@@ -440,3 +440,29 @@
       (is (= [(db/datom 1 :index {:map 3})]
             (vec (d/datoms db' :avet :index {:map 3} 1 )))))
 ))
+
+(deftest test-transitive-type-compare-386
+  #?(:cljs
+     (let [txs    [[{:block/uid "2LB4tlJGy"}]
+                   [{:block/uid "2ON453J0Z"}]
+                   [{:block/uid "2KqLLNbPg"}]
+                   [{:block/uid "2L0dcD7yy"}]
+                   [{:block/uid "2KqFNrhTZ"}]
+                   [{:block/uid "2KdQmItUD"}]
+                   [{:block/uid "2O8BcBfIL"}]
+                   [{:block/uid "2L4ZbI7nK"}]
+                   [{:block/uid "2KotiW36Z"}]
+                   [{:block/uid "2O4o-y5J8"}]
+                   [{:block/uid "2KimvuGko"}]
+                   [{:block/uid "dTR20ficj"}]
+                   [{:block/uid "wRmp6bXAx"}]
+                   [{:block/uid "rfL-iQOZm"}]
+                   [{:block/uid "tya6s422-"}]
+                   [{:block/uid 45619}]]
+           schema {:block/uid {:db/unique :db.unique/identity}}
+           conn   (d/create-conn schema)
+           _      (doseq [tx txs] (d/transact! conn tx))
+           db     @conn]
+       (is (empty? (->> (seq db)
+                        (map (fn [[_ a v]] [a v]))
+                        (remove #(d/entity db %))))))))

--- a/test/datascript/test/transact.cljc
+++ b/test/datascript/test/transact.cljc
@@ -442,27 +442,27 @@
 ))
 
 (deftest test-transitive-type-compare-386
-  #?(:cljs
-     (let [txs    [[{:block/uid "2LB4tlJGy"}]
-                   [{:block/uid "2ON453J0Z"}]
-                   [{:block/uid "2KqLLNbPg"}]
-                   [{:block/uid "2L0dcD7yy"}]
-                   [{:block/uid "2KqFNrhTZ"}]
-                   [{:block/uid "2KdQmItUD"}]
-                   [{:block/uid "2O8BcBfIL"}]
-                   [{:block/uid "2L4ZbI7nK"}]
-                   [{:block/uid "2KotiW36Z"}]
-                   [{:block/uid "2O4o-y5J8"}]
-                   [{:block/uid "2KimvuGko"}]
-                   [{:block/uid "dTR20ficj"}]
-                   [{:block/uid "wRmp6bXAx"}]
-                   [{:block/uid "rfL-iQOZm"}]
-                   [{:block/uid "tya6s422-"}]
-                   [{:block/uid 45619}]]
-           schema {:block/uid {:db/unique :db.unique/identity}}
-           conn   (d/create-conn schema)
-           _      (doseq [tx txs] (d/transact! conn tx))
-           db     @conn]
-       (is (empty? (->> (seq db)
-                        (map (fn [[_ a v]] [a v]))
-                        (remove #(d/entity db %))))))))
+  (let [txs    [[{:block/uid "2LB4tlJGy"}]
+                [{:block/uid "2ON453J0Z"}]
+                [{:block/uid "2KqLLNbPg"}]
+                [{:block/uid "2L0dcD7yy"}]
+                [{:block/uid "2KqFNrhTZ"}]
+                [{:block/uid "2KdQmItUD"}]
+                [{:block/uid "2O8BcBfIL"}]
+                [{:block/uid "2L4ZbI7nK"}]
+                [{:block/uid "2KotiW36Z"}]
+                [{:block/uid "2O4o-y5J8"}]
+                [{:block/uid "2KimvuGko"}]
+                [{:block/uid "dTR20ficj"}]
+                [{:block/uid "wRmp6bXAx"}]
+                [{:block/uid "rfL-iQOZm"}]
+                [{:block/uid "tya6s422-"}]
+                [{:block/uid 45619}]]
+        schema {:block/uid {:db/unique :db.unique/identity}}
+        conn   (d/create-conn schema)
+        _      (doseq [tx txs] (d/transact! conn tx))
+        db     @conn]
+    (is (empty? (->> (seq db)
+                     (map (fn [[_ a v]] [a v]))
+                     (remove #(d/entity db %)))))))
+


### PR DESCRIPTION
Fix #386