### PR TITLE
Allow :db/valueType :db.type/tuple

### DIFF
--- a/src/datascript/db.cljc
+++ b/src/datascript/db.cljc
@@ -728,8 +728,16 @@
            :key       :db/isComponent})))
 
     (validate-schema-key a :db/unique (:db/unique kv) #{:db.unique/value :db.unique/identity})
-    (validate-schema-key a :db/valueType (:db/valueType kv) #{:db.type/ref})
+    (validate-schema-key a :db/valueType (:db/valueType kv) #{:db.type/ref :db.type/tuple})
     (validate-schema-key a :db/cardinality (:db/cardinality kv) #{:db.cardinality/one :db.cardinality/many})
+
+    ;; tuple should have tupleAttrs
+    (when (and (= :db.type/tuple (:db/valueType kv))
+               (not (contains? kv :db/tupleAttrs)))
+      (raise "Bad attribute specification for " a ": {:db/valueType :db.type/tuple} should also have :db/tupleAttrs"
+             {:error :schema/validation
+              :attribute a
+              :key :db/valueType}))
 
     ;; :db/tupleAttrs is a non-empty sequential coll
     (when (contains? kv :db/tupleAttrs)

--- a/test/datascript/test/tuples.cljc
+++ b/test/datascript/test/tuples.cljc
@@ -10,7 +10,8 @@
   (let [db (d/empty-db
              {:year+session {:db/tupleAttrs [:year :session]}
               :semester+course+student {:db/tupleAttrs [:semester :course :student]}
-              :session+student {:db/tupleAttrs [:session :student]}})]
+              :session+student {:db/tupleAttrs [:session :student]
+                                :db/valueType :db.type/tuple}})]
     (is (= #{:year+session :semester+course+student :session+student}
           (:db.type/tuple (:rschema db))))
 
@@ -37,7 +38,9 @@
 
     (is (thrown-msg? ":t1 :db/tupleAttrs can’t depend on :db.cardinality/many attribute: :a"
           (d/empty-db {:a  {:db/cardinality :db.cardinality/many}
-                       :t1 {:db/tupleAttrs [:a :b :c]}})))))
+                       :t1 {:db/tupleAttrs [:a :b :c]}}))))
+  (is (thrown-msg? "Bad attribute specification for :foo+bar: {:db/valueType :db.type/tuple} should also have :db/tupleAttrs"
+        (d/empty-db {:foo+bar {:db/valueType :db.type/tuple}}))))
 
 (deftest test-tx
   (let [conn (d/create-conn {:a+b   {:db/tupleAttrs [:a :b]}


### PR DESCRIPTION
Allow specifying composite tuple with :db/valueType :db.type/tuple

This schema attribute is optional, but when specified will check that
:db/tupleAttrs is also provided.

This fixes #407 