### PR TITLE
Fix broken wildcard pull on non-matching ref

### DIFF
--- a/src/datascript/pull_api.cljc
+++ b/src/datascript/pull_api.cljc
@@ -267,7 +267,8 @@
 
 (defn pull-spec
   [db pattern eid multi?]
-  (pull-pattern db (list (initial-frame pattern [(db/entid db eid)] multi?))))
+  (when-let [id (db/entid db eid)]
+    (pull-pattern db (list (initial-frame pattern [id] multi?)))))
 
 (defn pull [db selector eid]
   {:pre [(db/db? db)]}

--- a/test/datascript/test/pull_api.cljc
+++ b/test/datascript/test/pull_api.cljc
@@ -336,6 +336,7 @@
                       [[:name "Elizabeth"]
                        [:name "Petr"]
                        [:name "Eunan"]
-                       [:name "Rebecca"]]))))
+                       [:name "Rebecca"]])))
+  (is (nil? (d/pull test-db '[*] [:name "No such name"]))))
 
 #_(t/test-ns 'datascript.test.pull-api)


### PR DESCRIPTION
A wildcard pull on a non-matching ref returns "garbage" attributes:

     (d/pull test-db '[*] [:name "No such name"])
     => {:db/id nil, :aka ["Devil" "Tupen"], :child [{:db/id 2} {:db/id 3}], :name "Petr", :father {:db/id 1}, :part [{:db/id 11, :name "Part A.A", :part [{:db/id 12, :name "Part A.A.A", :part [{:db/id 13, :name "Part A.A.A.A"} {:db/id 14, :name "Part A.A.A.B"}]}]} {:db/id 15, :name "Part A.B", :part [{:db/id 16, :name "Part A.B.A", :part [{:db/id 17, :name "Part A.B.A.A"} {:db/id 18, :name "Part A.B.A.B"}]}]} {:db/id 12, :name "Part A.A.A", :part [{:db/id 13, :name "Part A.A.A.A"} {:db/id 14, :name "Part A.A.A.B"}]} {:db/id 13, :name "Part A.A.A.A"} {:db/id 14, :name "Part A.A.A.B"} {:db/id 16, :name "Part A.B.A", :part [{:db/id 17, :name "Part A.B.A.A"} {:db/id 18, :name "Part A.B.A.B"}]} {:db/id 17, :name "Part A.B.A.A"} {:db/id 18, :name "Part A.B.A.B"}]}

See also the first commit in this PR for the full test.

The second commit fixes this issue by directly testing for a nil dbid in `pull-spec`. This is a very non-intrusive, straight-forward fix for the specific problem, but I'm unsure if there are other places where this issue pops up, since I'm not too familiar with the datascript codebase.

I'm open for suggestions on improving the PR.