### PR TITLE
Allow symbols as constants

### DIFF
--- a/src/datascript/parser.cljc
+++ b/src/datascript/parser.cljc
@@ -116,8 +116,9 @@
     (RulesVar.)))
 
 (defn parse-constant [form]
-  (when (not (symbol? form))
-    (Constant. form)))
+  (when-not (and (symbol? form)
+                 (= (first (name form)) \?))
+   (Constant. form)))
 
 (defn parse-plain-symbol [form]
   (when (and (symbol? form)
@@ -137,9 +138,8 @@
 
 (defn parse-fn-arg [form]
   (or (parse-variable form)
-      (parse-constant form)
-      (parse-src-var form)))
-
+      (parse-src-var form)
+      (parse-constant form)))
 
 ;; rule-vars = [ variable+ | ([ variable+ ] variable*) ]
 

--- a/test/datascript/test/parser_where.cljc
+++ b/test/datascript/test/parser_where.cljc
@@ -23,7 +23,13 @@
     (dp/->Pattern (dp/->SrcVar '$x) [(dp/->Placeholder) (dp/->Variable '?a) (dp/->Placeholder) (dp/->Placeholder)])
        
     '[$x _ :name ?v]
-    (dp/->Pattern (dp/->SrcVar '$x) [(dp/->Placeholder) (dp/->Constant :name) (dp/->Variable '?v)]))
+    (dp/->Pattern (dp/->SrcVar '$x) [(dp/->Placeholder) (dp/->Constant :name) (dp/->Variable '?v)])
+
+    '[$x _ sym ?v]
+    (dp/->Pattern (dp/->SrcVar '$x) [(dp/->Placeholder) (dp/->Constant 'sym) (dp/->Variable '?v)])
+
+    '[$x _ $src-sym ?v]
+    (dp/->Pattern (dp/->SrcVar '$x) [(dp/->Placeholder) (dp/->Constant '$src-sym) (dp/->Variable '?v)]))
 
     (is (thrown-with-msg? ExceptionInfo #"Pattern could not be empty"
                           (dp/parse-clause '[])))
@@ -64,13 +70,13 @@
     (dp/->RuleExpr (dp/->DefaultSrc) (dp/->PlainSymbol 'friends) [(dp/->Constant "Ivan") (dp/->Placeholder)])
 
     '($1 friends ?x ?y)
-    (dp/->RuleExpr (dp/->SrcVar '$1) (dp/->PlainSymbol 'friends) [(dp/->Variable '?x) (dp/->Variable '?y)]))
+    (dp/->RuleExpr (dp/->SrcVar '$1) (dp/->PlainSymbol 'friends) [(dp/->Variable '?x) (dp/->Variable '?y)])
+    
+    '(friends something)
+    (dp/->RuleExpr (dp/->DefaultSrc) (dp/->PlainSymbol 'friends) [(dp/->Constant 'something)]))
 
   (is (thrown-with-msg? ExceptionInfo #"rule-expr requires at least one argument"
-        (dp/parse-clause '(friends))))
-  
-  (is (thrown-with-msg? ExceptionInfo #"Cannot parse rule-expr arguments"
-        (dp/parse-clause '(friends something)))))
+        (dp/parse-clause '(friends)))))
 
 (deftest not-clause
   (are [clause res] (= (dp/parse-clause clause) res)


### PR DESCRIPTION
Closes #416. 

This PR allows using symbols(not starting with `?`) as constants in data patterns. This is consistent with Datomic's behaviour. 

Notes:

- I changed the order of parsers in `parse-fn-arg` otherwise `$x` would parse as a constant, and it shouldn't for function arguments.

- I believe the unit test saying `(friends something)` should throw is wrong. I've changed it to a positive test where `something` parses as a constant argument instead.