### PR TITLE
Render all variables in rule arity error message

### DIFF
--- a/src/datascript/parser.cljc
+++ b/src/datascript/parser.cljc
@@ -165,8 +165,8 @@
 (defn flatten-rule-vars [rule-vars]
   (concat
     (when (:required rule-vars)
-      [(mapv :symbol (:required rule-vars))]
-      (mapv :symbol (:free rule-vars)))))
+      [(mapv :symbol (:required rule-vars))])
+    (mapv :symbol (:free rule-vars))))
 
 (defn rule-vars-arity [rule-vars]
   [(count (:required rule-vars)) (count (:free rule-vars))])


### PR DESCRIPTION
Currently `flatten-rule-vars` will only return the free variable symbols if there are required variables. This is due to a misplaced `)`. This is not a big issue as `flatten-rule-vars` is only called in to generate an error message in rule arity validation.