### PR TITLE
Add get to built-ins for binding on map values

### DIFF
--- a/src/datascript/built_ins.cljc
+++ b/src/datascript/built_ins.cljc
@@ -78,9 +78,9 @@
      false)))
 
 (def query-fns {
-  '= =, '== ==, 'not= not=, '!= not=, 
-  '< less, '> greater, '<= less-equal, '>= greater-equal, 
-  '+ +, '- -, '* *, '/ /, 
+  '= =, '== ==, 'not= not=, '!= not=,
+  '< less, '> greater, '<= less-equal, '>= greater-equal,
+  '+ +, '- -, '* *, '/ /,
   'quot quot, 'rem rem, 'mod mod, 'inc inc, 'dec dec, 'max max, 'min min,
   'zero? zero?, 'pos? pos?, 'neg? neg?, 'even? even?, 'odd? odd?, 'compare compare,
   'rand rand, 'rand-int rand-int,
@@ -89,7 +89,8 @@
   'identity identity, 'keyword keyword, 'meta meta, 'name name, 'namespace namespace, 'type type,
   'vector vector, 'list list, 'set set, 'hash-map hash-map, 'array-map array-map,
   'count count, 'range range, 'not-empty not-empty, 'empty? empty?, 'contains? contains?,
-  'str str, 'pr-str pr-str, 'print-str print-str, 'println-str println-str, 'prn-str prn-str, 'subs subs,
+  'str str, 'subs, subs, 'get get,
+  'pr-str pr-str, 'print-str print-str, 'println-str println-str, 'prn-str prn-str,
   're-find re-find, 're-matches re-matches, 're-seq re-seq, 're-pattern re-pattern,
   '-differ? -differ?, 'get-else -get-else, 'get-some -get-some, 'missing? -missing?, 'ground identity,
   'clojure.string/blank? str/blank?, 'clojure.string/includes? str/includes?,
@@ -180,7 +181,7 @@
    'distinct set
    'min      aggregate-min
    'max      aggregate-max
-   'rand     aggregate-rand              
+   'rand     aggregate-rand
    'sample   aggregate-sample
    'count    count
    'count-distinct aggregate-count-distinct})

--- a/test/datascript/test/query.cljc
+++ b/test/datascript/test/query.cljc
@@ -230,6 +230,14 @@
               "X")
          #{["abcX"] ["aXb"]})))
 
+(deftest test-built-in-get
+  (is (= (d/q '[:find ?m ?m-value
+                :in [[?k ?m] ...] ?m-key
+                :where [(get ?m ?m-key) ?m-value]]
+              {:a {:b 1}
+               :c {:d 2}}
+              :d)
+         #{[{:d 2} 2]})))
 
 (deftest ^{:doc "issue-385"} test-join-unrelated
   (is (= #{}


### PR DESCRIPTION
Hi again! Would you be open to adding `get` to the builtins? It's the only thing keeping us @logseq from getting off of our datascript fork. I'm aware we could pass `get` as [an input](https://github.com/tonsky/datascript/issues/360) but are needs are a bit complex as our users already rely on this builtin to writing datalog queries in our editor. I'd also love for logseq to be using standard datascript so we can start to explore using datascript via bb. Thanks for this library as it has done wonders for logseq! Cheers