### PR TITLE
Allow symbols as data in where patterns

### DIFF
--- a/src/datascript/query.cljc
+++ b/src/datascript/query.cljc
@@ -316,7 +316,7 @@
 
 (defn lookup-pattern-db [db pattern]
   ;; TODO optimize with bound attrs min/max values here
-  (let [search-pattern (mapv #(if (symbol? %) nil %) pattern)
+  (let [search-pattern (mapv #(if (or (= % '_) (free-var? %)) nil %) pattern)
         datoms         (db/-search db search-pattern)
         attr->prop     (->> (map vector pattern ["e" "a" "v" "tx"])
                             (filter (fn [[s _]] (free-var? s)))
@@ -329,7 +329,7 @@
     (if (and tuple pattern)
       (let [t (first tuple)
             p (first pattern)]
-        (if (or (symbol? p) (= t p))
+        (if (or (= p '_) (free-var? p) (= t p))
           (recur (next tuple) (next pattern))
           false))
       true)))

--- a/test/datascript/test/query.cljc
+++ b/test/datascript/test/query.cljc
@@ -249,5 +249,21 @@
           (d/db-with (d/empty-db) [{:person/name "Joe"}])
           (fn [] 5)))))
 
+(deftest ^{:doc "issue-425"} test-symbol-comparison
+  (is (= [2]
+         (d/q
+          '[:find [?e ...]
+            :where [?e :s b]]
+          '[[1 :s a]
+            [2 :s b]])))
+  (let [db (-> (d/empty-db)
+               (d/db-with '[{:db/id 1, :s a}
+                            {:db/id 2, :s b}]))]
+    (is (= [2]
+           (d/q
+            '[:find [?e ...]
+              :where [?e :s b]]
+            db)))))
+
 #_(require 'datascript.test.query :reload)
 #_(clojure.test/test-ns 'datascript.test.query)


### PR DESCRIPTION
Closes #425

When a symbol in a data pattern is not `_` or starts with `?` we should consider it data.