### PR TITLE
Performance1

### DIFF
--- a/bench/datascript/bench/bench.cljc
+++ b/bench/datascript/bench/bench.cljc
@@ -5,8 +5,8 @@
 
 ; Measure time
 
-(def ^:dynamic *warmup-ms* 2000)
-(def ^:dynamic *bench-ms*  1000)
+(def ^:dynamic *warmup-ms* 10000)
+(def ^:dynamic *bench-ms*  20000)
 (def ^:dynamic *samples*   5)
 (def ^:dynamic *batch*     10)
 (def ^:dynamic *profile*   false)

--- a/deps.edn
+++ b/deps.edn
@@ -29,13 +29,14 @@
 
     :bench {
       :extra-paths ["bench"]
-      :jvm-opts ["-Djdk.attach.allowAttachSelf"
+      :jvm-opts ["-server"
                  "-XX:+UnlockDiagnosticVMOptions"
+                 "-Djdk.attach.allowAttachSelf"
                  "-XX:+DebugNonSafepoints"]
       :extra-deps {
         metosin/jsonista    {:mvn/version "0.3.3"}
         criterium/criterium {:mvn/version "0.4.6"}
-        com.clojure-goes-fast/clj-async-profiler {:mvn/version "0.5.1"}
+        com.clojure-goes-fast/clj-async-profiler {:mvn/version "1.0.0"}
       }
     }
 

--- a/src/datascript/core.cljc
+++ b/src/datascript/core.cljc
@@ -260,12 +260,7 @@
     {:pre [(db/db? db)]}
     (if (is-filtered db)
       (throw (ex-info "Filtered DB cannot be modified" {:error :transaction/filtered}))
-      (db/transact-tx-data (db/map->TxReport
-                             { :db-before db
-                               :db-after  db
-                               :tx-data   []
-                               :tempids   {}
-                               :tx-meta   tx-meta}) tx-data))))
+      (db/transact-tx-data (db/->TxReport db db [] {} tx-meta) tx-data))))
 
 
 (defn db-with

--- a/src/datascript/db.cljc
+++ b/src/datascript/db.cljc
@@ -1047,13 +1047,21 @@
   ^long [db]
   (inc (long (:max-eid db))))
 
-(defn- #?@(:clj  [^Boolean tx-id?]
-           :cljs [^boolean tx-id?])
-  [e]
-  (or (= e :db/current-tx)
-      (= e ":db/current-tx") ;; for datascript.js interop
-      (= e "datomic.tx")
-      (= e "datascript.tx")))
+#?(:clj
+   (defn- ^Boolean tx-id?
+     [e]
+     (or (identical? :db/current-tx e)
+         (.equals ":db/current-tx" e) ;; for datascript.js interop
+         (.equals "datomic.tx" e)
+         (.equals "datascript.tx" e)))
+
+   :cljs
+   (defn- ^boolean tx-id?
+     [e]
+     (or (= e :db/current-tx)
+         (= e ":db/current-tx") ;; for datascript.js interop
+         (= e "datomic.tx")
+         (= e "datascript.tx"))))
 
 (defn- #?@(:clj  [^Boolean tempid?]
            :cljs [^boolean tempid?])

--- a/src/datascript/db.cljc
+++ b/src/datascript/db.cljc
@@ -564,28 +564,28 @@
         [(set/slice eavt (datom e a v tx) (datom e a v tx))                   ;; e a v tx
          (set/slice eavt (datom e a v tx0) (datom e a v txmax))               ;; e a v _
          (->> (set/slice eavt (datom e a nil tx0) (datom e a nil txmax))      ;; e a _ tx
-              (filter (fn [^Datom d] (= tx (datom-tx d)))))
+              (->Eduction (filter (fn [^Datom d] (= tx (datom-tx d))))))
          (set/slice eavt (datom e a nil tx0) (datom e a nil txmax))           ;; e a _ _
          (->> (set/slice eavt (datom e nil nil tx0) (datom e nil nil txmax))  ;; e _ v tx
-              (filter (fn [^Datom d] (and (= v (.-v d))
-                                          (= tx (datom-tx d))))))
+              (->Eduction (filter (fn [^Datom d] (and (= v (.-v d))
+                                          (= tx (datom-tx d)))))))
          (->> (set/slice eavt (datom e nil nil tx0) (datom e nil nil txmax))  ;; e _ v _
-              (filter (fn [^Datom d] (= v (.-v d)))))
+              (->Eduction (filter (fn [^Datom d] (= v (.-v d))))))
          (->> (set/slice eavt (datom e nil nil tx0) (datom e nil nil txmax))  ;; e _ _ tx
-              (filter (fn [^Datom d] (= tx (datom-tx d)))))
+              (->Eduction (filter (fn [^Datom d] (= tx (datom-tx d))))))
          (set/slice eavt (datom e nil nil tx0) (datom e nil nil txmax))       ;; e _ _ _
          (if (indexing? db a)                                                   ;; _ a v tx
            (->> (set/slice avet (datom e0 a v tx0) (datom emax a v txmax))      
-                (filter (fn [^Datom d] (= tx (datom-tx d)))))
+                (->Eduction (filter (fn [^Datom d] (= tx (datom-tx d))))))
            (->> (set/slice aevt (datom e0 a nil tx0) (datom emax a nil txmax))
-                (filter (fn [^Datom d] (and (= v (.-v d))
-                                            (= tx (datom-tx d)))))))
+                (->Eduction (filter (fn [^Datom d] (and (= v (.-v d))
+                                            (= tx (datom-tx d))))))))
          (if (indexing? db a)                                                   ;; _ a v _
            (set/slice avet (datom e0 a v tx0) (datom emax a v txmax))
            (->> (set/slice aevt (datom e0 a nil tx0) (datom emax a nil txmax))
-                (filter (fn [^Datom d] (= v (.-v d))))))
+                (->Eduction (filter (fn [^Datom d] (= v (.-v d)))))))
          (->> (set/slice aevt (datom e0 a nil tx0) (datom emax a nil txmax))  ;; _ a _ tx
-              (filter (fn [^Datom d] (= tx (datom-tx d)))))
+              (->Eduction (filter (fn [^Datom d] (= tx (datom-tx d))))))
          (set/slice aevt (datom e0 a nil tx0) (datom emax a nil txmax))       ;; _ a _ _
          (filter (fn [^Datom d] (and (= v (.-v d))
                                      (= tx (datom-tx d)))) eavt)                ;; _ _ v tx

--- a/src/datascript/db.cljc
+++ b/src/datascript/db.cljc
@@ -1037,8 +1037,10 @@
     (raise "Cannot store nil as a value at " at
            {:error :transact/syntax, :value v, :context at})))
 
-(defn- current-tx [report]
-  (inc (get-in report [:db-before :max-tx])))
+(defn- current-tx
+  #?(:clj {:inline (fn [report] `(-> ~report :db-before :max-tx long inc))})
+  ^long [report]
+  (-> report :db-before :max-tx long inc))
 
 (defn- next-eid [db]
   (inc (:max-eid db)))

--- a/src/datascript/db.cljc
+++ b/src/datascript/db.cljc
@@ -1,17 +1,14 @@
 (ns ^:no-doc ^:lean-ns datascript.db
-  #?(:clj (:refer-clojure :exclude [update]))
   (:require
     #?(:cljs [goog.array :as garray])
     [clojure.walk]
     [clojure.data]
+    [datascript.inline :refer [update]]
     [datascript.lru :as lru]
     [me.tonsky.persistent-sorted-set :as set]
     [me.tonsky.persistent-sorted-set.arrays :as arrays])
   #?(:cljs (:require-macros [datascript.db :refer [case-tree combine-cmp raise defrecord-updatable cond+]]))
-  (:refer-clojure :exclude [seqable?])) 
-
-#?(:clj (ns-unmap *ns* 'update))
-#?(:clj (require '[datascript.inline :refer [update]]))
+  (:refer-clojure :exclude [seqable? #?(:clj update)]))
 
 #?(:clj (set! *warn-on-reflection* true))
 

--- a/src/datascript/db.cljc
+++ b/src/datascript/db.cljc
@@ -1042,8 +1042,10 @@
   ^long [report]
   (-> report :db-before :max-tx long inc))
 
-(defn- next-eid [db]
-  (inc (:max-eid db)))
+(defn- next-eid
+  #?(:clj {:inline (fn [db] `(inc (long (:max-eid ~db))))})
+  ^long [db]
+  (inc (long (:max-eid db))))
 
 (defn- #?@(:clj  [^Boolean tx-id?]
            :cljs [^boolean tx-id?])

--- a/src/datascript/db.cljc
+++ b/src/datascript/db.cljc
@@ -621,9 +621,19 @@
     (diff-sorted (:eavt a) (:eavt b) cmp-datoms-eav-quick)))
 
 (defn db? [x]
-  (and (satisfies? ISearch x)
-       (satisfies? IIndexAccess x)
-       (satisfies? IDB x)))
+  #?(:clj
+     (or
+      (and x
+           (instance? datascript.db.ISearch x)
+           (instance? datascript.db.IIndexAccess x)
+           (instance? datascript.db.IDB x))
+      (and (satisfies? ISearch x)
+           (satisfies? IIndexAccess x)
+           (satisfies? IDB x)))
+     :cljs
+     (and (satisfies? ISearch x)
+          (satisfies? IIndexAccess x)
+          (satisfies? IDB x))))
 
 ;; ----------------------------------------------------------------------------
 (defrecord-updatable FilteredDB [unfiltered-db pred hash]

--- a/src/datascript/db.cljc
+++ b/src/datascript/db.cljc
@@ -1,4 +1,5 @@
 (ns ^:no-doc ^:lean-ns datascript.db
+  #?(:clj (:refer-clojure :exclude [update]))
   (:require
     #?(:cljs [goog.array :as garray])
     [clojure.walk]
@@ -8,6 +9,9 @@
     [me.tonsky.persistent-sorted-set.arrays :as arrays])
   #?(:cljs (:require-macros [datascript.db :refer [case-tree combine-cmp raise defrecord-updatable cond+]]))
   (:refer-clojure :exclude [seqable?])) 
+
+#?(:clj (ns-unmap *ns* 'update))
+#?(:clj (require '[datascript.inline :refer [update]]))
 
 #?(:clj (set! *warn-on-reflection* true))
 

--- a/src/datascript/db.cljc
+++ b/src/datascript/db.cljc
@@ -381,8 +381,11 @@
         (throw e)))))
 
 (defn value-cmp
-  #?(:clj {:inline (fn [x y] `(let [x# ~x y# ~y]
-                               (if (nil? x#) 0 (if (nil? y#) 0 (value-compare x# y#)))))})
+  #?(:clj
+     {:inline
+      (fn [x y]
+        `(let [x# ~x y# ~y]
+           (if (nil? x#) 0 (if (nil? y#) 0 (value-compare x# y#)))))})
   ^long [x y]
   (if (nil? x) 0 (if (nil? y) 0 (value-compare x y))))
 

--- a/src/datascript/inline.clj
+++ b/src/datascript/inline.clj
@@ -1,0 +1,37 @@
+(ns datascript.inline
+  (:refer-clojure :exclude [assoc update]))
+
+(defn assoc
+  {:inline
+   (fn
+     ([m k v]
+      `(clojure.lang.RT/assoc ~m ~k ~v))
+     ([m k v & kvs]
+      (assert (even? (count kvs)))
+      `(assoc (assoc ~m ~k ~v) ~@kvs)))}
+  ([map key val] (clojure.lang.RT/assoc map key val))
+  ([map key val & kvs]
+   (let [ret (clojure.lang.RT/assoc map key val)]
+     (if kvs
+       (if (next kvs)
+         (recur ret (first kvs) (second kvs) (nnext kvs))
+         (throw (IllegalArgumentException.
+                 "assoc expects even number of arguments after map/vector, found odd number")))
+       ret))))
+
+(defn update
+  {:inline
+   (fn
+     ([m k f & more]
+      `(let [m# ~m k# ~k]
+         (assoc m# k# (~f (get m# k#) ~@more)))))}
+  ([m k f]
+   (assoc m k (f (get m k))))
+  ([m k f x]
+   (assoc m k (f (get m k) x)))
+  ([m k f x y]
+   (assoc m k (f (get m k) x y)))
+  ([m k f x y z]
+   (assoc m k (f (get m k) x y z)))
+  ([m k f x y z & more]
+   (assoc m k (apply f (get m k) x y z more))))

--- a/src/datascript/query.cljc
+++ b/src/datascript/query.cljc
@@ -19,6 +19,8 @@
        Constant FindColl FindRel FindScalar FindTuple PlainSymbol
        RulesVar SrcVar Variable])))
 
+#?(:clj (set! *warn-on-reflection* true))
+
 ;; ----------------------------------------------------------------------------
 
 (def ^:dynamic *query-cache* (lru/cache 100))

--- a/src/datascript/query.cljc
+++ b/src/datascript/query.cljc
@@ -308,9 +308,15 @@
         common-gtrs1  (map #(getter-fn attrs1 %) common-attrs)
         common-gtrs2  (map #(getter-fn attrs2 %) common-attrs)
         keep-attrs1   (keys attrs1)
-        keep-attrs2   (vec (set/difference (set (keys attrs2)) (set (keys attrs1))))
-        keep-idxs1    (to-array (map attrs1 keep-attrs1))
-        keep-idxs2    (to-array (map attrs2 keep-attrs2))
+        keep-attrs2   (->> attrs2
+                           (reduce-kv (fn [vec k _]
+                                        (if (attrs1 k)
+                                          vec
+                                          (conj! vec k)))
+                                      (transient []))
+                           persistent!) ; keys in attrs2-attrs1
+        keep-idxs1    (to-array (vals attrs1))
+        keep-idxs2    (to-array (->Eduction (map attrs2) keep-attrs2)) ; vals in attrs2-attrs1 by keys
         key-fn1       (tuple-key-fn common-gtrs1)
         hash          (hash-attrs key-fn1 tuples1)
         key-fn2       (tuple-key-fn common-gtrs2)

--- a/src/datascript/query.cljc
+++ b/src/datascript/query.cljc
@@ -788,9 +788,7 @@
        symbols))))
 
 (defn collect [context symbols]
-  (->> (-collect context symbols)
-       (map vec)
-       set))
+  (into #{} (map vec) (-collect context symbols)))
 
 (defprotocol IContextResolve
   (-context-resolve [var context]))

--- a/src/datascript/query.cljc
+++ b/src/datascript/query.cljc
@@ -281,14 +281,17 @@
         (list* #?(:cljs (.map getters #(% tuple))
                   :clj  (to-array (map #(% tuple) getters))))))))
 
+(defn -group-by
+  [f init coll]
+  (persistent!
+   (reduce
+    (fn [ret x]
+      (let [k (f x)]
+        (assoc! ret k (conj (get ret k init) x))))
+    (transient {}) coll)))
+
 (defn hash-attrs [key-fn tuples]
-  (loop [tuples     tuples
-         hash-table (transient {})]
-    (if-some [tuple (first tuples)]
-      (let [key (key-fn tuple)]
-        (recur (next tuples)
-               (assoc! hash-table key (conj (get hash-table key '()) tuple))))
-      (persistent! hash-table))))
+  (-group-by key-fn '() tuples))
 
 (defn hash-join [rel1 rel2]
   (let [tuples1       (:tuples rel1)

--- a/src/datascript/query.cljc
+++ b/src/datascript/query.cljc
@@ -264,14 +264,20 @@
   (let [idx (attrs attr)]
     (if (contains? *lookup-attrs* attr)
       (fn [tuple]
-        (let [eid (#?(:cljs da/aget :clj get) tuple idx)]
+        (let [eid #?(:cljs (da/aget tuple idx)
+                     :clj (if (.isArray (.getClass ^Object tuple))
+                            (aget ^objects tuple idx)
+                            (get tuple idx)))]
           (cond
             (number? eid)     eid ;; quick path to avoid fn call
             (sequential? eid) (db/entid *implicit-source* eid)
             (da/array? eid)   (db/entid *implicit-source* eid)
             :else             eid)))
       (fn [tuple]
-        (#?(:cljs da/aget :clj get) tuple idx)))))
+        #?(:cljs (da/aget tuple idx)
+           :clj (if (.isArray (.getClass ^Object tuple))
+                  (aget ^objects tuple idx)
+                  (get tuple idx)))))))
 
 (defn tuple-key-fn [getters]
   (if (== (count getters) 1)


### PR DESCRIPTION
There are lots of commits in this MR which break the changes apart, but comparing the benchmarks before and after:


```
Java 8

add-1                 373.2 -> 235.6 ms/op   
add-5                 596.3 -> 470.9 ms/op   
add-all               589.3 -> 477.9 ms/op   
freeze                552.6 -> 548.4 ms/op   
init                   19.8 ->  18.1 ms/op   
pull-many               1.2 ->   1.1 ms/op   
pull-many-entities      3.2 ->   2.9 ms/op   
pull-one              0.644 -> 0.568 ms/op   
pull-one-entities       1.1 -> 0.977 ms/op   
pull-wildcard           1.5 ->   1.4 ms/op   
q1                      1.4 -> 0.692 ms/op   
q2                      3.4 ->   2.2 ms/op   
q3                      4.9 ->   3.2 ms/op   
q4                      7.7 ->   4.6 ms/op   
qpred1                  4.7 ->   4.4 ms/op   
qpred2                 14.8 ->  10.0 ms/op   
retract-5             474.3 -> 394.6 ms/op   

Java 17

add-1                 363.1 -> 232.0 ms/op   
add-5                 577.9 -> 450.0 ms/op   
add-all               561.0 -> 454.9 ms/op   
freeze                577.5 -> 562.9 ms/op   
init                   21.1 ->  20.1 ms/op   
pull-many               1.2 ->   1.2 ms/op   
pull-many-entities      2.9 ->   2.7 ms/op   
pull-one              0.628 -> 0.615 ms/op   
pull-one-entities       1.0 -> 0.892 ms/op   
pull-wildcard           1.4 ->   1.4 ms/op   
q1                      1.3 -> 0.753 ms/op   
q2                      3.2 ->   2.4 ms/op   
q3                      4.6 ->   3.3 ms/op   
q4                      7.4 ->   4.8 ms/op   
qpred1                  5.3 ->   4.6 ms/op   
qpred2                 15.4 ->   9.6 ms/op   
retract-5             459.2 -> 384.1 ms/op   
```