### PR TITLE
Entity should return nil for numeric eids that don't correspond to entities

### DIFF
--- a/src/datascript/core.cljc
+++ b/src/datascript/core.cljc
@@ -75,9 +75,7 @@
 (def ^{:arglists '([db eid])
        :doc "Given lookup ref `[unique-attr value]`, returns numberic entity id.
 
-             If entity does not exist, returns `nil`.
-
-             For numeric `eid` returns `eid` itself (does not check for entity existence in that case)."}
+             If entity does not exist, returns `nil`."}
   entid db/entid)
 
 

--- a/src/datascript/db.cljc
+++ b/src/datascript/db.cljc
@@ -1066,6 +1066,9 @@
     (raise "Expected number or lookup ref for entity id, got " eid
       {:error :entity-id/syntax, :entity-id eid})))
 
+(defn numeric-eid-exists? [db eid]
+  (= eid (-> (-seek-datoms db :eavt [eid]) first :e)))
+
 (defn entid-strict [db eid]
   (or (entid db eid)
       (raise "Nothing found for entity id " eid

--- a/src/datascript/impl/entity.cljc
+++ b/src/datascript/impl/entity.cljc
@@ -14,7 +14,8 @@
 (defn entity [db eid]
   {:pre [(db/db? db)]}
   (when-let [e (entid db eid)]
-    (->Entity db e (volatile! false) (volatile! {}))))
+    (when (db/numeric-eid-exists? db e)
+      (->Entity db e (volatile! false) (volatile! {})))))
 
 (defn- entity-attr [db a datoms]
   (if (db/multival? db a)

--- a/test/datascript/test/entity.cljc
+++ b/test/datascript/test/entity.cljc
@@ -88,7 +88,7 @@
     (is (nil? (d/entity db "abc")))
     (is (nil? (d/entity db :keyword)))
     (is (nil? (d/entity db [:name "Petr"])))
-    (is (= 777 (:db/id (d/entity db 777))))
+    (is (nil? (d/entity db 777)))
     (is (thrown-msg? "Lookup ref attribute should be marked as :db/unique: [:not-an-attr 777]"
           (d/entity db [:not-an-attr 777])))))
 

--- a/test/datascript/test/lookup_refs.cljc
+++ b/test/datascript/test/lookup_refs.cljc
@@ -83,7 +83,7 @@
       {:db/id 1 :name "Ivan"}
          
       [[:db.fn/retractEntity [:name "Ivan"]]]
-      {:db/id 1})
+      nil)
     
     (are [tx msg] (thrown-msg? msg (d/db-with db tx))
       [{:db/id [:name "Oleg"], :age 10}]

--- a/test/js/tests.js
+++ b/test/js/tests.js
@@ -253,9 +253,7 @@ function test_entity() {
   assert_ident(db, e.db);
   
   var e2 = d.entity(db, 2);
-  assert_eq(null, e2.get("name"));
-  assert_eq(null, e2.get("aka"));
-  assert_eq(2,    e2.get(":db/id"));
+  assert_eq(null, e2);
 
   // js interop
   assert_eq_set(["name", "aka"], e.key_set());
@@ -283,10 +281,10 @@ function test_entity_refs() {
   var db = d.db_with(d.empty_db(schema), 
                          [{":db/id": 1,   "children": [10]},
                           {":db/id": 10,  "father":   1, "children": [100, 101]},
-                          {":db/id": 100, "father":   10}]);
+                          {":db/id": 100, "father":   10},
+                          {":db/id": 101, "father":   10}]);
   
   var e = function(id) { return d.entity(db, id); };
-  
   assert_eq_refs([10], e(1).get("children"));
   assert_eq_refs([101, 100], e(10).get("children"));
   
@@ -299,11 +297,11 @@ function test_entity_refs() {
   assert_eq_refs([10],       e(10).get("father").get("children"));
   
   // backward navigation
-  assert_eq     (null,  e(1).get("_children"));
-  assert_eq_refs([10],  e(1).get("_father"));
-  assert_eq_refs([1],   e(10).get("_children"));
-  assert_eq_refs([100], e(10).get("_father"));
-  assert_eq_refs([1],   e(100).get("_children")[0].get("_children"));
+  assert_eq     (null,       e(1).get("_children"));
+  assert_eq_refs([10],       e(1).get("_father"));
+  assert_eq_refs([1],        e(10).get("_children"));
+  assert_eq_refs([100, 101], e(10).get("_father"));
+  assert_eq_refs([1],        e(100).get("_children")[0].get("_children"));
 }
 
 function test_pull() {
@@ -313,7 +311,8 @@ function test_pull() {
   var db = d.db_with(d.empty_db(schema),
                          [{":db/id": 1,   "name": "Ivan", "children": [10]},
                           {":db/id": 10,  "father":   1, "children": [100, 101]},
-                          {":db/id": 100, "father":   10}]);
+                          {":db/id": 100, "father":   10},
+                          {":db/id": 101, "father":   10}]);
 
   var actual, expected;
 


### PR DESCRIPTION
Ref: https://github.com/tonsky/datascript/issues/447

I'm not sure about the fastest way to check that an entity exists in the database.
I used `(empty? (db/-search db [e]))` here, but presumably there's some allocation overhead from creating an iterator.

Perhaps there's a cheaper way to do it (maybe seeking on the index directly and checking for an eid match?)
I'm open to suggestions and am happy to take a second look later with profiling if desired.