### PR TITLE
prevent explosion of redundant tuples during rule solving

### DIFF
--- a/src/datascript/query.cljc
+++ b/src/datascript/query.cljc
@@ -609,7 +609,8 @@
 
             ;; no rules -> expand, collect, sum
             (let [context (solve (:prefix-context frame) clauses)
-                  tuples  (collect context final-attrs)
+                  tuples  #?(:clj (collect context final-attrs)
+                             :cljs (-collect context final-attrs))
                   new-rel (Relation. final-attrs-map tuples)]
               (recur (next stack) (sum-rel rel new-rel)))
 

--- a/src/datascript/query.cljc
+++ b/src/datascript/query.cljc
@@ -26,7 +26,7 @@
 
 (def ^:dynamic *query-cache* (lru/cache 100))
 
-(declare -collect -resolve-clause resolve-clause)
+(declare -collect collect -resolve-clause resolve-clause)
 
 ;; Records
 
@@ -609,7 +609,7 @@
 
             ;; no rules -> expand, collect, sum
             (let [context (solve (:prefix-context frame) clauses)
-                  tuples  (-collect context final-attrs)
+                  tuples  (collect context final-attrs)
                   new-rel (Relation. final-attrs-map tuples)]
               (recur (next stack) (sum-rel rel new-rel)))
 

--- a/test/datascript/test/query_rules.cljc
+++ b/test/datascript/test/query_rules.cljc
@@ -190,3 +190,40 @@
           (d/q '[:find ?id :in $ %
                  :where (is ?id false)]
             db rules)))))
+
+
+; https://github.com/tonsky/datascript/issues/456
+; this used to stall for nearly a minute and/or fail with an OOM exception
+; due to propagation of a relation with duplicate tuples during rule solving
+(deftest test-rule-performance-on-larger-datasets
+  (letfn [(inline [db]
+            (d/q '[:find ?e
+                   :where
+                   [?e :item/status ?status]
+                   [(ground "pending") ?status]]
+                 db))
+          (rule [db]
+            (d/q '[:find ?e
+                   :in $ %
+                   :where
+                   [?e :item/status ?status]
+                   (pending? ?status)]
+                 db
+                 '[[(pending? ?status)
+                    [(ground "pending") ?status]]]))
+          (measure [f & args]
+            (let [start  (System/currentTimeMillis)
+                  result (apply f args)
+                  end    (System/currentTimeMillis)]
+              [(- end start) result]))]
+    (let [db (-> (d/empty-db)
+                 (d/db-with (for [x    (range 50000)
+                                  :let [temp (str (gensym))]
+                                  fact [[:db/add temp :item/id x]
+                                        [:db/add temp :item/status (rand-nth ["started" "pending" "stopped"])]]]
+                              fact)))
+          [inline-time inline-result] (measure inline db)
+          [rule-time rule-result] (measure rule db)]
+      (is (= inline-result rule-result))
+      ; show that rule performance continues to be within an order of magnitude of inline performance
+      (is (<= 0 rule-time (* 10 inline-time))))))


### PR DESCRIPTION
Addresses performance problem reported in https://github.com/tonsky/datascript/issues/456

Prior to this change `tuples` contained a bunch of duplicates due to calling `-collect` instead of `collect` which does deduplication. Those duplicates then propagated across the relations causing an unnecessary amount of work.