### PR TITLE
Bugfixes for sum-rel and shortcircuited or/or-join branches

### DIFF
--- a/src/datascript/query.cljc
+++ b/src/datascript/query.cljc
@@ -133,7 +133,9 @@
       (= attrs-a attrs-b)
       (Relation. attrs-a (into (vec tuples-a) tuples-b))
 
-      (not (same-keys? attrs-a attrs-b))
+      (and (not (same-keys? attrs-a attrs-b))
+           (seq tuples-a)  ; could be empty because
+           (seq tuples-b)) ; a query short-circuited
       (raise "Can’t sum relations with different attrs: " attrs-a " and " attrs-b
              {:error :query/where})
 

--- a/test/datascript/test/query_or.cljc
+++ b/test/datascript/test/query_or.cljc
@@ -65,7 +65,16 @@
          (and [2  :age  ?a]
               [?e :name "Oleg"]))
      [?e :age ?a]]
-    #{1 5 4}))
+    #{1 5 4}
+
+    ;; One branch of or short-circuits resolution
+    [(or
+       (and [?e :age 30] ; no matches in db
+            [?e :name ?n])
+       (and [?e :age 20]
+            [?e :name ?n]))
+     [(ground "Ivan") ?n]]
+    #{2 6}))
 
 (deftest test-or-join
   (are [q res] (= (d/q (concat '[:find ?e :where] (quote q)) @test-db)
@@ -83,16 +92,9 @@
             [?e2 :age ?a]))]
     #{1 2 3 4 5 6}
 
+    ;; One branch of or-join short-circuits resolution
     [(or-join [?e ?n]
-       (and [?e :age 30] ; no matches, so this branch short-circuits
-            [?e :name ?n])
-       (and [?e :age 20]
-            [?e :name ?n]))
-     [(ground "Ivan") ?n]]
-    #{2 6}
-
-    [(or
-       (and [?e :age 30] ; no matches, so this branch short-circuits
+       (and [?e :age 30] ; no matches in db
             [?e :name ?n])
        (and [?e :age 20]
             [?e :name ?n]))

--- a/test/datascript/test/query_or.cljc
+++ b/test/datascript/test/query_or.cljc
@@ -81,7 +81,23 @@
      (or-join [?e]
        (and [?e  :age ?a]
             [?e2 :age ?a]))]
-    #{1 2 3 4 5 6})
+    #{1 2 3 4 5 6}
+
+    [(or-join [?e ?n]
+       (and [?e :age 30] ; no matches, so this branch short-circuits
+            [?e :name ?n])
+       (and [?e :age 20]
+            [?e :name ?n]))
+     [(ground "Ivan") ?n]]
+    #{2 6}
+
+    [(or
+       (and [?e :age 30] ; no matches, so this branch short-circuits
+            [?e :name ?n])
+       (and [?e :age 20]
+            [?e :name ?n]))
+     [(ground "Ivan") ?n]]
+    #{2 6})
 
   ;; #348
   (is (= #{[1] [3] [4] [5]}


### PR DESCRIPTION
[My previous PR](https://github.com/tonsky/datascript/pull/459) inadvertently broke or/or-join when a branch shortcircuits due to being empty. (Sorry!)

If one branch of an `or` or `or-join` short-circuited, the resulting Relation would not have the expected attrs, resulting in `Can’t sum relations with different attrs` being raised.

This fixes the bug and adds regression tests. Fixing that also exposed an extant bug in `same-keys?` which is now fixed.