### PR TITLE
[clj] serialize bigdecs as other type, for cross-platform compatibility.

### DIFF
--- a/src/datascript/serialize.cljc
+++ b/src/datascript/serialize.cljc
@@ -138,6 +138,7 @@
                       (cond
                         (string? v)  v
                         #?@(:clj [(ratio? v) (write-other v)])
+                        #?@(:clj [(decimal? v) (write-other v)])
                         
                         (number? v)  
                         (cond


### PR DESCRIPTION
This is required if you have a server (clj) serialized datascript DB that is deserialized by a client (cljs).  Since cljs does not have a notion of bigdec, it has to be handled specially be the `thaw-fn`.  Fixes #466 