### PR TITLE
treat a query as a progressive funnel instead of independent clauses to search and join

### DIFF
--- a/src/datascript/query.cljc
+++ b/src/datascript/query.cljc
@@ -831,7 +831,6 @@
                  (sum-rel relation (Relation. bindings (:tuples rel')))))
              (Relation. bindings [])
              bound-patterns)]
-       (println "relation" relation)
        (binding [*lookup-attrs*
                  *lookup-attrs*]
          (update context :rels collapse-rels relation))))))


### PR DESCRIPTION
Hey!

Let's consider this a work in progress since I broke something around lookup refs (will look into it) and I know you might want to make some different implementation decisions. However, the query tests are passing and this greatly reduces the number of datoms being fetched from storage in many cases.

Your fix for https://github.com/tonsky/datascript/issues/462 addressed the "constant / one possibility" case but it didn't do anything to constrain the search space in most other cases (like when there are only a few possible values for a binding as determined by an earlier where clause). 

Here I'm constraining the search space of where clauses using candidate binding values (which considerably decreases the number of datoms that need to be scanned for clauses appearing later in a query). In other words, this handles both the "constant" case and allows relations from earlier where clauses to turn later searches into "a collection of constant cases".