### PR TITLE
Fix :db.fn/call returning entity without :db/id

### DIFF
--- a/src/datascript/db.cljc
+++ b/src/datascript/db.cljc
@@ -1766,7 +1766,7 @@
           (util/cond+
             (= op :db.fn/call)
             (let [[_ f & args] entity]
-              (recur report (concat (apply f db args) entities)))
+              (recur report (concat (assoc-auto-tempids db (apply f db args)) entities)))
             
             (and (keyword? op)
               (not (builtin-fn? op)))

--- a/test/datascript/test/transact.cljc
+++ b/test/datascript/test/transact.cljc
@@ -474,3 +474,10 @@
     (is (empty? (->> (d/datoms db :eavt)
                   (map (fn [[_ a v]] [a v]))
                   (remove #(d/entity db %)))))))
+
+(deftest test-db-fn-returning-entity-without-db-id-issue-474
+  (let [conn   (d/create-conn {})
+        _      (d/transact! conn [[:db.fn/call (fn [db]
+                                                 [{:foo "bar"}])]])
+        db     @conn]
+    (is (= #{[1 :foo "bar"]} (tdc/all-datoms db)))))


### PR DESCRIPTION
Potential fix for #474, not sure if ideal.