### PR TITLE
fix: error when find-datom on empty-db

### DIFF
--- a/src/datascript/db.cljc
+++ b/src/datascript/db.cljc
@@ -1149,7 +1149,7 @@
         cmp     #?(:clj (.comparator ^clojure.lang.Sorted set) :cljs (.-comparator set))
         from    (components->pattern db index c0 c1 c2 c3 e0 tx0)
         to      (components->pattern db index c0 c1 c2 c3 emax txmax)
-        datom   (first (set/seek (seq set) from))]
+        datom   (when-let [set* (seq set)] (first (set/seek set* from)))]
     (when (and (some? datom) (<= 0 (cmp to datom)))
       datom)))
 


### PR DESCRIPTION
`d/find-datom` will throw an error when calling on an empty-db.
Is this behavior by design or a mistake?

``` clojure
> (d/find-datom (d/empty-db {:age {:db/index true}}) :eavt)
Execution error (NullPointerException) at me.tonsky.persistent-sorted-set/seek (persistent_sorted_set.clj:51).
Cannot invoke "me.tonsky.persistent_sorted_set.Seq.seek(Object)" because "seq" is null
```

I expect it to return `nil` when an empty-db is used as arg to `find-datom`.

