### PR TITLE
Patch es6 iterators not having Symbol.iterator function

### DIFF
--- a/src/datascript/impl/entity.cljc
+++ b/src/datascript/impl/entity.cljc
@@ -45,6 +45,16 @@
          [a (multival->js v)]
          [a v]))))
 
+#?(:cljs
+  (unchecked-set (.-prototype ES6Iterator) cljs.core/ITER_SYMBOL
+     (fn []
+       (this-as this# this#))))
+
+#?(:cljs
+  (unchecked-set (.-prototype ES6EntriesIterator) cljs.core/ITER_SYMBOL
+     (fn []
+       (this-as this# this#))))
+
 (deftype Entity [db eid touched cache]
   #?@(:cljs
       [Object

--- a/test/js/tests.js
+++ b/test/js/tests.js
@@ -304,6 +304,22 @@ function test_entity_refs() {
   assert_eq_refs([1],        e(100).get("_children")[0].get("_children"));
 }
 
+function test_entity_iterators() {
+  var schema = {"aka": {":db/cardinality": ":db.cardinality/many"}};
+  var db = d.db_with(d.empty_db(schema),
+                         [{":db/id": 1,
+                           "name": "Ivan",
+                           "aka": ["X", "Y"]},
+                          {":db/id": 2}]);
+  var e = d.entity(db, 1);
+  var keys = [...e.keys()];
+  assert_eq_set(["name", "aka"], keys);
+  var values = [...e.values()];
+  assert_eq_set(["Ivan", ["X", "Y"]], values);
+  var entries = [...e.entries()];
+  assert_eq_set([["name", "Ivan"], ["aka", ["X", "Y"]]], entries);
+}
+
 function test_pull() {
   var schema = {"father":   {":db/valueType":   ":db.type/ref"},
                 "children": {":db/valueType":   ":db.type/ref",
@@ -547,6 +563,7 @@ function test_datascript_js() {
                     test_conn,
                     test_entity,
                     test_entity_refs,
+                    test_entity_iterators,
                     test_pull,
                     test_lookup_refs,
                     test_resolve_current_tx,


### PR DESCRIPTION
closes #249

This should probably be fixed in Clojurescript itself but I'm out of my depth here already (I am a Clojure noob).

We can't do `(es6-iterable ES6Iterator)` because that would be infinite recursion so we patch the `ES6Iterator` prototype with the `Symbol.iterator` directly, sans recursion.

Interestingly enough `cljs.core/keys` already returns a `KeySeq` which has `Symbol.iterator` but no `next` function. Applying `es6-iterator`, as we do, seems give it the `next` function but strip `Symbol.iterator`.


This doesn't yet fix `[...e]` because I'm not quite sure what the intention there is, I guess the same as `[...e.entries()]`?

