### PR TITLE
direct-linking fix: use clojure.core/declare for JVM clojure

### DIFF
--- a/src/datascript/db.cljc
+++ b/src/datascript/db.cljc
@@ -409,7 +409,7 @@
   #?(:clj  (. clojure.lang.Util (hasheq x))
      :cljs (hash x)))
 
-(declare+ ^number value-compare [x y])
+#?(:cljs (declare+ ^number value-compare [x y]) :clj (declare value-compare))
 
 (defn- seq-compare [xs ys]
   (let [cx (count xs)
@@ -1619,7 +1619,7 @@
               (filter (fn [^Datom d] (component? db (.-a d))))
               (map (fn [^Datom d] [:db.fn/retractEntity (.-v d)]))) datoms))
 
-(declare+ transact-tx-data-impl [initial-report initial-es])
+#?(:cljs (declare+ transact-tx-data-impl [initial-report initial-es]) :clj (declare transact-tx-data-impl))
 
 (defn- retry-with-tempid [initial-report report es tempid upserted-eid]
   (if-some [eid (get (::upserted-tempids initial-report) tempid)]

--- a/src/datascript/db.cljc
+++ b/src/datascript/db.cljc
@@ -163,17 +163,17 @@
 
 ;; ----------------------------------------------------------------------------
 
-(declare+ ^number hash-datom [d])
+#?(:cljs (declare+ ^number hash-datom [d]) :clj (declare hash-datom))
 
-(declare+ ^boolean equiv-datom [d o])
+#?(:cljs (declare+ ^boolean equiv-datom [d o]) :clj (declare equiv-datom))
 
-(declare+ seq-datom [d])
+#?(:cljs (declare+ seq-datom [d]) :clj (declare seq-datom))
 
-(declare+ nth-datom [d i] [d i not-found])
+#?(:cljs (declare+ nth-datom [d i] [d i not-found]) :clj (declare nth-datom))
 
-(declare+ assoc-datom [d k v])
+#?(:cljs (declare+ assoc-datom [d k v]) :clj (declare assoc-datom))
 
-(declare+ val-at-datom [d k not-found])
+#?(:cljs (declare+ val-at-datom [d k not-found]) :clj (declare val-at-datom))
 
 (defprotocol IDatom
   (datom-tx [this])
@@ -584,22 +584,22 @@
 
 ;; ----------------------------------------------------------------------------
 
-(declare+ ^number hash-db [db])
+#?(:cljs (declare+ ^number hash-db [db]) :clj (declare hash-db))
 
-(declare+ ^number hash-fdb [db])
+#?(:cljs (declare+ ^number hash-fdb [db]) :clj (declare hash-fdb))
 
-(declare+ ^boolean equiv-db [db other])
+#?(:cljs (declare+ ^boolean equiv-db [db other]) :clj (declare equiv-db))
 
-(declare+ restore-db [keys])
+#?(:cljs (declare+ restore-db [keys]) :clj (declare restore-db))
 
-(declare+ ^boolean indexing? [db attr])
+#?(:cljs (declare+ ^boolean indexing? [db attr]) :clj (declare indexing?))
 
 #?(:cljs
    (declare+ pr-db [db w opts]))
 
-(declare+ resolve-datom [db e a v t default-e default-tx])
+#?(:cljs (declare+ resolve-datom [db e a v t default-e default-tx]) :clj (declare resolve-datom))
 
-(declare+ components->pattern [db index c0 c1 c2 c3 default-e default-tx])
+#?(:cljs (declare+ components->pattern [db index c0 c1 c2 c3 default-e default-tx]) :clj (declare components->pattern))
 
 ;;;;;;;;;; Fast validation
 
@@ -1122,9 +1122,9 @@
 
 ;; ----------------------------------------------------------------------------
 
-(declare+ ^number entid-strict [db eid])
+#?(:cljs (declare+ ^number entid-strict [db eid]) :clj (declare entid-strict))
 
-(declare+ ^boolean ref? [db attr])
+#?(:cljs (declare+ ^boolean ref? [db attr]) :clj (declare ref?))
 
 (defn+ resolve-datom [db e a v t default-e default-tx]
   (when (some? a)


### PR DESCRIPTION
**Problem:** 

When Direct Linking is enabled, many public functions do not work, in the case below `nth-datom` cannot be found – NoSuchMethodError. 

Here's an inline repro:


```clojure
clj -Sdeps '{:deps {datascript/datascript {:mvn/version "1.7.4"}}}' -J-Dclojure.compiler.direct-linking=true
Clojure 1.12.0
user=> (require '[datascript.core :as d])
nil
user=> (nth (d/datom 1 :e "v") 0)
Execution error (NoSuchMethodError) at datascript.db.Datom/nth (db.cljc:184).
'java.lang.Object datascript.db$nth_datom.invokeStatic(java.lang.Object, java.lang.Object)'
user=> 

```

**(likely) Root cause:**
Certain fns are declared with a custom macro, `(declare+ ...)`. When direct linking is enabled, those fns are not found.

**(potential) Fix:**
From reading some of the docstrings in `(ns datascript.db)` I inferred that `(declare+ ...)` is only required for ClojureScript. I tried completely bypassing it for Clojure JVM and it seems to work. Please let me know if there are bigger implications that I am not seeing. 
